### PR TITLE
Fix PosEnd for contenteditable inputs

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -48,18 +48,45 @@
     });
 
     function PosEnd(end) {
-        var len = end.value.length;
+        if (!end) {
+            return;
+        }
 
-        // Mostly for Web Browsers
-        if (end.setSelectionRange) {
+        const textLength = (typeof end.textContent === "string")
+            ? end.textContent.length
+            : (typeof end.value === "string" ? end.value.length : 0);
+
+        if (typeof end.setSelectionRange === "function" && typeof end.value === "string") {
             end.focus();
-            end.setSelectionRange(len, len);
-        } else if (end.createTextRange) {
-            var t = end.createTextRange();
-            t.collapse(true);
-            t.moveEnd('character', len);
-            t.moveStart('character', len);
-            t.select();
+            end.setSelectionRange(textLength, textLength);
+            return;
+        }
+
+        if (end.isContentEditable) {
+            end.focus();
+            const selection = window.getSelection();
+            if (!selection) {
+                return;
+            }
+
+            const range = document.createRange();
+            if (end.childNodes && end.childNodes.length > 0) {
+                range.setStart(end, end.childNodes.length);
+            } else {
+                range.selectNodeContents(end);
+            }
+            range.collapse(false);
+            selection.removeAllRanges();
+            selection.addRange(range);
+            return;
+        }
+
+        if (typeof end.createTextRange === "function") {
+            const textRange = end.createTextRange();
+            textRange.collapse(true);
+            textRange.moveEnd('character', textLength);
+            textRange.moveStart('character', textLength);
+            textRange.select();
         }
     }
 


### PR DESCRIPTION
## Summary
- update the PosEnd helper to derive caret offsets from textContent and to focus contenteditable nodes with Selection/Range APIs
- guard setSelectionRange usage to elements with value properties while keeping the legacy createTextRange fallback

## Testing
- python - <<'PY'
from playwright.async_api import async_playwright
import asyncio

async def main():
    async with async_playwright() as p:
        browser = await p.chromium.launch(args=["--no-sandbox"], headless=True)
        page = await browser.new_page()
        await page.add_init_script("window.__consoleErrors = []; const originalError = console.error.bind(console); console.error = (...args) => { window.__consoleErrors.push(args.map(String).join(' ')); originalError(...args); }; window.__TAURI__ = { invoke: () => Promise.resolve() };")
        await page.goto("http://127.0.0.1:8000/", wait_until="domcontentloaded")
        await page.wait_for_selector("#repl_input", state="attached")
        await page.evaluate("document.getElementById('repl_input').focus();")
        await page.keyboard.type("line1")
        await page.keyboard.press("Shift+Enter")
        await page.keyboard.type("line2")
        content = await page.evaluate("document.getElementById('repl_input').innerText")
        errors = await page.evaluate("window.__consoleErrors")
        await browser.close()
    print("CONTENT:", repr(content))
    print("CONSOLE_ERRORS:", errors)

asyncio.run(main())
PY

------
https://chatgpt.com/codex/tasks/task_e_68cf212384f08325b29ca6bc41d62392