### PR TITLE
Add macOS build workflow and document prerequisites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,29 @@ jobs:
       - name: Tests
         working-directory: src-tauri
         run: cargo test
+
+  macos-build:
+    runs-on: macos-13
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build macOS bundle
+        run: npm run tauri build -- --target universal-apple-darwin
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-tauri-bundle
+          path: src-tauri/target/release/bundle/macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ navigation, and workspace details in a single interface so that exploratory data
 
 ## Prerequisites
 
-The project targets recent Linux distributions. Ensure the following tooling is available before running the application or
-its test suite:
+The project targets recent Linux distributions and macOS releases. Ensure the following tooling is available before running
+the application or its test suite:
 
 - [Rust](https://www.rust-lang.org/tools/install) toolchain (`rustup` with the `stable` toolchain is recommended)
 - `node` and `npm` for the frontend assets when building the full desktop bundle
-- System libraries required by WebKitGTK and GTK3:
+- Linux hosts require the system libraries needed by WebKitGTK and GTK3:
   ```bash
   sudo apt-get update
   sudo apt-get install -y \
@@ -22,6 +22,8 @@ its test suite:
     libsoup2.4-dev \
     patchelf
   ```
+- macOS hosts require Xcode command-line tools (for SDK headers and signing utilities) in addition to the Rust and Node.js
+  toolchains. The Tauri bundler will also use the system `codesign` binary during `npm run tauri build`.
 
 > [!NOTE]
 > Ubuntu 24.04 currently publishes WebKitGTK 4.1. When developing on that release you may need to provide compatibility
@@ -47,7 +49,8 @@ cargo doc --no-deps
 ## Continuous integration
 
 GitHub Actions validates every commit with formatting (`cargo fmt`), linting (`cargo clippy` with pedantic warnings), and the
-Rust test suite. CI runs on `ubuntu-22.04` to match Tauri's current Linux support matrix.
+Rust test suite on `ubuntu-22.04`. A dedicated `macos-13` job installs the Rust and Node.js toolchains, builds the universal
+macOS bundle via `npm run tauri build -- --target universal-apple-darwin`, and uploads the resulting `.app` artifact.
 
 ## Running the desktop application
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ the application or its test suite:
     patchelf
   ```
 - macOS hosts require Xcode command-line tools (for SDK headers and signing utilities) in addition to the Rust and Node.js
-  toolchains. The Tauri bundler will also use the system `codesign` binary during `npm run tauri build`.
+  toolchains. Install the `aarch64-apple-darwin` Rust target via `rustup target add aarch64-apple-darwin` so universal bundles
+  can be produced. The Tauri bundler will also use the system `codesign` binary during `npm run tauri build`.
 
 > [!NOTE]
 > Ubuntu 24.04 currently publishes WebKitGTK 4.1. When developing on that release you may need to provide compatibility


### PR DESCRIPTION
## Summary
- add a macOS GitHub Actions job that installs Rust and Node.js, builds the universal Tauri bundle, and uploads the artifact
- document the macOS prerequisites and CI coverage in the README

## Testing
- not run (workflow and documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68df0b613ba88325801b98917cc06944