### PR TITLE
Fix macOS artifact upload path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: macos-tauri-bundle
-          path: src-tauri/target/release/bundle/macos
+          path: |
+            src-tauri/target/universal-apple-darwin/release/bundle/macos/pastrami.app
+            src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
+          components: rustfmt,clippy
 
       - name: Cache cargo registry
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- update the macOS CI artifact upload to point at the universal build output

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68df39296ec88325956d987e1f20318b