### PR TITLE
Make package toggles parsing robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,11 @@ npm run tauri
 ```
 
 This will build the frontend, compile the Rust backend, and open the desktop shell with hot-reload enabled.
+
+## Loading Rhai community packages
+
+Open the **Settings** button in the upper-right corner of the interface to load additional Rhai packages at runtime. The
+modal lists the curated [`rhaiscript`](https://github.com/orgs/rhaiscript/repositories?type=all) packages bundled with the
+application. Enable the checkboxes for [`rhai-sci`](https://github.com/rhaiscript/rhai-sci) or
+[`rhai-ml`](https://github.com/rhaiscript/rhai-ml) to register their APIs in the interactive REPL and one-off script runner
+without restarting the app. Clearing all checkboxes reverts to the base Rhai engine.

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,6 +13,11 @@
     </style>
 </head>
 <body style="background-color: black">
+<div class="position-absolute" style="right: 1rem; top: 1rem; z-index: 1030;">
+    <button type="button" class="btn btn-outline-light btn-sm" data-toggle="modal" data-target="#settingsModal">
+        Settings
+    </button>
+</div>
 <div class="container-fluid h-100 min-vh-100 p-0">
     <div class="row w-100 m-0" id="output_holder" >
         <div class="col h-100 min-vh-100 "style="background-color: #2B2B2B;">
@@ -25,12 +30,41 @@
         </div>
     </div>
 </div>
+<div class="modal fade" id="settingsModal" tabindex="-1" role="dialog" aria-labelledby="settingsModalTitle"
+     aria-hidden="true">
+    <div class="modal-dialog modal-dialog-scrollable" role="document">
+        <div class="modal-content bg-dark text-light">
+            <div class="modal-header border-secondary">
+                <h5 class="modal-title" id="settingsModalTitle">Rhai Packages</h5>
+                <button type="button" class="close text-light" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body" id="packageList">
+                <p class="text-muted mb-0">Loading available packages…</p>
+            </div>
+            <div class="modal-footer border-secondary">
+                <a class="mr-auto text-info" href="https://github.com/orgs/rhaiscript/repositories?type=all"
+                   target="_blank" rel="noreferrer noopener">
+                    Explore Rhai community packages
+                </a>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="savePackageSelection">Load Packages</button>
+            </div>
+        </div>
+    </div>
+</div>
 <script>
 
     document.getElementById("repl_input").focus();
 
-    // access the pre-bundled global API functions
-    const invoke = window.__TAURI__.invoke;
+    // access the pre-bundled global API functions when available
+    const tauriApi = window.__TAURI__ || {};
+    const invoke = typeof tauriApi.invoke === 'function'
+        ? tauriApi.invoke.bind(tauriApi)
+        : async () => {
+            throw new Error('Tauri API not available');
+        };
     document.body.setAttribute('spellcheck', false);
 
     document.getElementById("repl_input").addEventListener("keydown", function (e) {
@@ -43,7 +77,9 @@
             let script = document.getElementById("repl_input").textContent;
             document.getElementById("repl_input").innerText = "";
             append_output(">>> " + script, false);
-            invoke('rhai_repl', {script: script});
+            invoke('rhai_repl', {script: script}).catch((error) => {
+                append_output(`#Failed to run script: ${error}`);
+            });
         }
     });
 
@@ -88,6 +124,75 @@
             textRange.moveStart('character', textLength);
             textRange.select();
         }
+    }
+
+    const packageModal = document.getElementById("settingsModal");
+    const packageList = document.getElementById("packageList");
+    const packageSaveButton = document.getElementById("savePackageSelection");
+
+    packageModal.addEventListener('show.bs.modal', async () => {
+        packageList.innerHTML = '<p class="text-muted mb-0">Loading available packages…</p>';
+        try {
+            const packages = await invoke('list_available_packages');
+            renderPackageOptions(packages);
+        } catch (error) {
+            packageList.innerHTML = '';
+            append_output(`#Failed to load packages: ${error}`);
+        }
+    });
+
+    packageSaveButton.addEventListener('click', async () => {
+        const selected = Array.from(
+            packageList.querySelectorAll('input.package-checkbox:checked')
+        ).map((checkbox) => checkbox.value);
+
+        try {
+            await invoke('update_packages', {selected});
+            const summary = selected.length > 0 ? selected.join(', ') : 'none';
+            append_output(`Loaded packages: ${summary}`);
+            if (window.jQuery) {
+                window.jQuery(packageModal).modal('hide');
+            }
+        } catch (error) {
+            append_output(`#Failed to update packages: ${error}`);
+        }
+    });
+
+    function escapeHtml(value) {
+        if (typeof value !== 'string') {
+            return '';
+        }
+
+        return value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function renderPackageOptions(packages) {
+        if (!Array.isArray(packages) || packages.length === 0) {
+            packageList.innerHTML = '<p class="text-muted mb-0">No packages available.</p>';
+            return;
+        }
+
+        packageList.innerHTML = packages.map((pkg) => {
+            const checked = pkg.selected ? 'checked' : '';
+            const safeName = escapeHtml(pkg.name);
+            const safeDescription = escapeHtml(pkg.description);
+            const safeRepository = escapeHtml(pkg.repository);
+            return `
+                <div class="custom-control custom-checkbox mb-3">
+                    <input type="checkbox" class="custom-control-input package-checkbox" id="pkg-${safeName}" value="${safeName}" ${checked}>
+                    <label class="custom-control-label" for="pkg-${safeName}">
+                        <strong>${safeName}</strong>
+                        <span class="d-block text-muted small">${safeDescription}</span>
+                        <a class="text-info" href="${safeRepository}" target="_blank" rel="noreferrer noopener">${safeRepository}</a>
+                    </label>
+                </div>
+            `;
+        }).join('');
     }
 
     function append_output(payload) {

--- a/dist/index_script.html
+++ b/dist/index_script.html
@@ -50,14 +50,22 @@
 </div>
 <script>
     // access the pre-bundled global API functions
-    const invoke = window.__TAURI__.invoke
+    const tauriApi = window.__TAURI__ || {};
+    const invoke = typeof tauriApi.invoke === 'function'
+        ? tauriApi.invoke.bind(tauriApi)
+        : async () => {
+            throw new Error('Tauri API not available');
+        };
 
     toggle_spinner();
     append_output('Welcome to pastrami on rhai!');
 
     function run_script() {
         toggle_spinner();
-        invoke('rhai_script', {script: document.getElementById("script").value});
+        invoke('rhai_script', {script: document.getElementById("script").value}).catch((error) => {
+            append_output(`#Failed to run script: ${error}`);
+            toggle_spinner();
+        });
     }
 
     function append_output(s) {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -89,6 +89,7 @@ name = "app"
 version = "0.1.0"
 dependencies = [
  "rhai",
+ "rhai-ml",
  "rhai-sci",
  "serde",
  "serde_json",
@@ -3185,6 +3186,20 @@ dependencies = [
  "num-traits",
  "rhai_codegen",
  "smallvec",
+ "smartstring",
+]
+
+[[package]]
+name = "rhai-ml"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7eba35d506c40bbc178f3dd4598b9d6f34654956df53b3da4885803c9b428d7"
+dependencies = [
+ "bincode",
+ "rhai",
+ "serde",
+ "serde_json",
+ "smartcore",
  "smartstring",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.0.5", features = ["api-all"] }
 rhai-sci = { version = "0.1.9", features = ["smartcore", "nalgebra", "rand", "io"] }
+rhai-ml = "0.1.2"
 rhai = { version = "1.9.0", features= ["sync"] }
 
 [features]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,6 +4,8 @@
 )]
 use std::sync::{Arc, Mutex};
 
+use serde::Serialize;
+
 /// Builds a JavaScript snippet that safely forwards a message to the frontend.
 ///
 /// The message is serialized using `serde_json` so that newline characters,
@@ -32,37 +34,124 @@ fn send_output(window: &tauri::Window, message: &str) {
     }
 }
 
-struct MyState(Mutex<rhai::Engine>, Mutex<rhai::Scope<'static>>);
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PackageToggles {
+    sci: bool,
+    ml: bool,
+}
+
+impl Default for PackageToggles {
+    fn default() -> Self {
+        Self {
+            sci: true,
+            ml: false,
+        }
+    }
+}
+
+impl PackageToggles {
+    fn apply_to_engine(&self, engine: &mut rhai::Engine) {
+        if self.sci {
+            engine.register_global_module(SciPackage::new().as_shared_module());
+        }
+
+        if self.ml {
+            engine.register_global_module(MLPackage::new().as_shared_module());
+        }
+    }
+
+    fn update_from_selection<'a, I>(&mut self, selected: I)
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        let mut sci_enabled = false;
+        let mut ml_enabled = false;
+
+        for entry in selected {
+            let trimmed = entry.trim();
+
+            if trimmed.eq_ignore_ascii_case("rhai-sci") {
+                sci_enabled = true;
+            } else if trimmed.eq_ignore_ascii_case("rhai-ml") {
+                ml_enabled = true;
+            }
+        }
+
+        self.sci = sci_enabled;
+        self.ml = ml_enabled;
+    }
+
+    #[cfg(test)]
+    fn is_selected(&self, package: &str) -> bool {
+        match package {
+            "rhai-sci" => self.sci,
+            "rhai-ml" => self.ml,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct PackageDescriptor {
+    name: String,
+    description: String,
+    repository: String,
+    selected: bool,
+}
+
+struct MyState {
+    engine: Mutex<rhai::Engine>,
+    scope: Mutex<rhai::Scope<'static>>,
+    packages: Mutex<PackageToggles>,
+}
 
 fn main() {
+    let packages = PackageToggles::default();
     let mut engine = rhai::Engine::new();
+    packages.apply_to_engine(&mut engine);
     let scope = rhai::Scope::new();
-    engine.register_global_module(SciPackage::new().as_shared_module());
 
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![rhai_repl, rhai_script])
-        .manage(MyState(Mutex::new(engine), Mutex::new(scope)))
+        .invoke_handler(tauri::generate_handler![
+            rhai_repl,
+            rhai_script,
+            list_available_packages,
+            update_packages
+        ])
+        .manage(MyState {
+            engine: Mutex::new(engine),
+            scope: Mutex::new(scope),
+            packages: Mutex::new(packages),
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
 
 use rhai::packages::Package;
+use rhai_ml::MLPackage;
 use rhai_sci::SciPackage;
 
+#[allow(clippy::needless_pass_by_value)] // Tauri command signature requires owned `Window`/`State`.
 #[tauri::command]
-fn rhai_script(script: &str, window: tauri::Window) {
+fn rhai_script(script: &str, window: tauri::Window, state: tauri::State<MyState>) {
     let output_sink: OutputSink = Arc::new(move |message: String| {
         send_output(&window, &message);
     });
 
-    run_rhai_script_with_sink(script, &output_sink);
+    let selected_packages = state
+        .packages
+        .lock()
+        .expect("package mutex poisoned")
+        .clone();
+
+    run_rhai_script_with_sink(script, &output_sink, &selected_packages);
 }
 
 #[allow(clippy::needless_pass_by_value)]
 #[tauri::command]
 fn rhai_repl(script: &str, window: tauri::Window, state: tauri::State<MyState>) {
-    let mut engine = state.0.lock().unwrap();
-    let mut scope = state.1.lock().unwrap();
+    let mut engine = state.engine.lock().unwrap();
+    let mut scope = state.scope.lock().unwrap();
     let window_for_print = window.clone();
     engine.on_print(move |message| {
         send_output(&window_for_print, message);
@@ -96,9 +185,9 @@ type OutputSink = Arc<dyn Fn(String) + Send + Sync + 'static>;
 /// run_rhai_script_with_sink("40 + 2", &sink);
 /// assert_eq!(output.lock().unwrap().as_slice(), ["42"]);
 /// ```
-fn run_rhai_script_with_sink(script: &str, sink: &OutputSink) {
+fn run_rhai_script_with_sink(script: &str, sink: &OutputSink, packages: &PackageToggles) {
     let mut engine = rhai::Engine::new();
-    engine.register_global_module(SciPackage::new().as_shared_module());
+    packages.apply_to_engine(&mut engine);
 
     let print_sink = Arc::clone(sink);
     engine.on_print(move |x| {
@@ -116,10 +205,10 @@ fn run_rhai_script_with_sink(script: &str, sink: &OutputSink) {
 
 #[cfg(test)]
 mod tests {
-    use super::{append_output_script, run_rhai_script_with_sink, OutputSink};
+    use super::{append_output_script, run_rhai_script_with_sink, OutputSink, PackageToggles};
     use std::sync::{Arc, Mutex};
 
-    fn run_script_with_collector(script: &str) -> Vec<String> {
+    fn run_script_with_collector(script: &str, packages: &PackageToggles) -> Vec<String> {
         let captured_output: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
         let sink_target = Arc::clone(&captured_output);
         let sink: OutputSink = Arc::new(move |message: String| {
@@ -129,7 +218,7 @@ mod tests {
                 .push(message);
         });
 
-        run_rhai_script_with_sink(script, &sink);
+        run_rhai_script_with_sink(script, &sink, packages);
 
         let collected = captured_output
             .lock()
@@ -155,7 +244,7 @@ mod tests {
 
     #[test]
     fn invalid_script_reports_parse_error() {
-        let output = run_script_with_collector("let x = ;");
+        let output = run_script_with_collector("let x = ;", &PackageToggles::default());
         let last_message = output
             .last()
             .expect("missing output entry for invalid script");
@@ -168,7 +257,7 @@ mod tests {
 
     #[test]
     fn valid_script_reports_result() {
-        let output = run_script_with_collector("40 + 2");
+        let output = run_script_with_collector("40 + 2", &PackageToggles::default());
         assert!(
             output.contains(&"42".to_string()),
             "expected valid script to produce \"42\" but saw {output:?}",
@@ -182,6 +271,7 @@ mod tests {
             fn explode() { throw("boom"); }
             explode();
             "#,
+            &PackageToggles::default(),
         );
 
         let last_message = output
@@ -195,7 +285,8 @@ mod tests {
 
     #[test]
     fn print_statements_are_captured_before_results() {
-        let output = run_script_with_collector(r#"print("hi"); 41 + 1;"#);
+        let output =
+            run_script_with_collector(r#"print("hi"); 41 + 1;"#, &PackageToggles::default());
 
         assert_eq!(
             output,
@@ -203,4 +294,97 @@ mod tests {
             "expected print output to precede the result"
         );
     }
+
+    #[test]
+    fn package_selection_can_toggle_sci_and_ml_modules() {
+        let mut packages = PackageToggles::default();
+        assert!(packages.sci, "sci should be enabled by default");
+        assert!(!packages.ml, "ml should be disabled by default");
+
+        packages.update_from_selection(["rhai-ml"]);
+
+        assert!(
+            !packages.sci,
+            "updating selection without rhai-sci should disable the sci package"
+        );
+        assert!(
+            packages.ml,
+            "updating selection with rhai-ml should enable the ml package"
+        );
+
+        assert!(packages.is_selected("rhai-ml"));
+        assert!(
+            !packages.is_selected("rhai-sci"),
+            "unexpected leftover rhai-sci selection"
+        );
+    }
+
+    #[test]
+    fn package_selection_ignores_whitespace_and_case() {
+        let mut packages = PackageToggles::default();
+        packages.update_from_selection(["  RhAi-ML  "]);
+
+        assert!(
+            packages.ml,
+            "expected ml toggle to become active when name includes whitespace and mixed case",
+        );
+
+        packages.update_from_selection(["  RHAI-SCI  "]);
+
+        assert!(
+            packages.sci,
+            "expected sci toggle to become active when name is mixed case",
+        );
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)] // Tauri commands must take `State` by value.
+#[tauri::command]
+fn list_available_packages(state: tauri::State<MyState>) -> Vec<PackageDescriptor> {
+    let selected = state
+        .packages
+        .lock()
+        .expect("package mutex poisoned")
+        .clone();
+
+    vec![
+        PackageDescriptor {
+            name: "rhai-sci".to_string(),
+            description: "Scientific and numerical utilities built on smartcore and nalgebra"
+                .to_string(),
+            repository: "https://github.com/rhaiscript/rhai-sci".to_string(),
+            selected: selected.sci,
+        },
+        PackageDescriptor {
+            name: "rhai-ml".to_string(),
+            description: "Machine learning helpers for Rhai scripts".to_string(),
+            repository: "https://github.com/rhaiscript/rhai-ml".to_string(),
+            selected: selected.ml,
+        },
+    ]
+}
+
+#[allow(clippy::needless_pass_by_value)] // Tauri commands must take `State` by value.
+#[tauri::command]
+fn update_packages(selected: Vec<String>, state: tauri::State<MyState>) {
+    let mut package_state = state.packages.lock().expect("package mutex poisoned");
+
+    let mut new_selection = package_state.clone();
+    new_selection.update_from_selection(selected.iter().map(std::string::String::as_str));
+
+    if *package_state == new_selection {
+        return;
+    }
+
+    *package_state = new_selection.clone();
+
+    let mut engine = state.engine.lock().unwrap();
+    *engine = {
+        let mut refreshed = rhai::Engine::new();
+        new_selection.apply_to_engine(&mut refreshed);
+        refreshed
+    };
+
+    let mut scope = state.scope.lock().unwrap();
+    *scope = rhai::Scope::new();
 }


### PR DESCRIPTION
## Summary
- normalize package selections by trimming and comparing case-insensitively
- extend package toggle unit tests to cover mixed-case and whitespace inputs
- reuse existing selection logic when applying Tauri updates without extra allocation

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings -W clippy::pedantic
- cargo test --manifest-path src-tauri/Cargo.toml


------
https://chatgpt.com/codex/tasks/task_e_68dfcb0d7a288325b138f048627e0903