### PR TITLE
Make desktop feature optional for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ cargo test
 ```
 
 Enable the `desktop` feature whenever you want to lint or test code paths that
-depend on the Tauri runtime:
+depend on the Tauri runtime (the `custom-protocol` feature is an equivalent
+alias used by the Tauri bundler):
 
 ```bash
 cargo clippy --all-targets --features desktop -- -D warnings -W clippy::pedantic
@@ -73,12 +74,19 @@ npm install
 npm run tauri dev -- --features desktop
 ```
 
-This will build the frontend, compile the Rust backend with the `desktop` feature enabled, and open the desktop shell with
-hot-reload enabled. Build artifacts for distribution can be produced with:
+This will build the frontend, compile the Rust backend with the `desktop`
+feature enabled, and open the desktop shell with hot-reload enabled. Build
+artifacts for distribution can be produced with:
 
 ```bash
 npm run tauri build -- --features desktop
 ```
+
+> [!TIP]
+> The Tauri bundler enables the `custom-protocol` feature automatically. This
+> repository maps that feature to the optional Tauri dependency so CI builds and
+> local commands such as `npm run tauri build -- --target universal-apple-darwin`
+> continue to work without additional flags.
 
 ## Loading Rhai community packages
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,22 @@ the application or its test suite:
 
 ## Development workflow
 
-Run the following commands from the repository root to validate changes locally:
+The Rust backend now exposes a headless default build that keeps the heavy
+system dependencies used by Tauri optional. Run the following commands from the
+repository root to validate changes locally:
 
 ```bash
 cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic
+cargo clippy --all-targets -- -D warnings -W clippy::pedantic
 cargo test
+```
+
+Enable the `desktop` feature whenever you want to lint or test code paths that
+depend on the Tauri runtime:
+
+```bash
+cargo clippy --all-targets --features desktop -- -D warnings -W clippy::pedantic
+cargo test --features desktop
 ```
 
 Documentation for the Rust components can be generated with:
@@ -60,10 +70,15 @@ prerequisites you can launch the development build with:
 
 ```bash
 npm install
-npm run tauri
+npm run tauri dev -- --features desktop
 ```
 
-This will build the frontend, compile the Rust backend, and open the desktop shell with hot-reload enabled.
+This will build the frontend, compile the Rust backend with the `desktop` feature enabled, and open the desktop shell with
+hot-reload enabled. Build artifacts for distribution can be produced with:
+
+```bash
+npm run tauri build -- --features desktop
+```
 
 ## Loading Rhai community packages
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,4 +22,5 @@ rhai = { version = "1.9.0", features= ["sync"] }
 
 [features]
 default = []
-desktop = ["tauri", "tauri/custom-protocol"]
+desktop = ["custom-protocol"]
+custom-protocol = ["tauri", "tauri/custom-protocol"]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,15 +15,11 @@ tauri-build = { version = "1.0.4", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.0.5", features = ["api-all"] }
+tauri = { version = "1.0.5", features = ["api-all"], optional = true }
 rhai-sci = { version = "0.1.9", features = ["smartcore", "nalgebra", "rand", "io"] }
 rhai-ml = "0.1.2"
 rhai = { version = "1.9.0", features= ["sync"] }
 
 [features]
-# by default Tauri runs in production mode
-# when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL
-default = [ "custom-protocol" ]
-# this feature is used used for production builds where `devPath` points to the filesystem
-# DO NOT remove this
-custom-protocol = [ "tauri/custom-protocol" ]
+default = []
+desktop = ["tauri", "tauri/custom-protocol"]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,0 +1,263 @@
+use std::sync::Arc;
+
+use rhai::packages::Package;
+use rhai_ml::MLPackage;
+use rhai_sci::SciPackage;
+
+/// A sink that consumes output strings emitted by Rhai scripts.
+pub type OutputSink = Arc<dyn Fn(String) + Send + Sync + 'static>;
+
+/// Builds a JavaScript snippet that safely forwards a message to the frontend.
+///
+/// The message is serialized using `serde_json` so that newline characters,
+/// quotes, and other special characters remain valid once evaluated in the
+/// webview.
+///
+/// # Examples
+/// ```
+/// use app::append_output_script;
+///
+/// let script = append_output_script("Hello" ).unwrap();
+/// assert_eq!(script, "append_output(\"Hello\")");
+/// ```
+///
+/// # Errors
+///
+/// Returns [`serde_json::Error`] if the provided message cannot be serialized to
+/// JSON.
+pub fn append_output_script(message: &str) -> Result<String, serde_json::Error> {
+    serde_json::to_string(message).map(|escaped| format!("append_output({escaped})"))
+}
+
+/// Keeps track of which Rhai extension packages are enabled.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PackageToggles {
+    sci: bool,
+    ml: bool,
+}
+
+impl Default for PackageToggles {
+    fn default() -> Self {
+        Self {
+            sci: true,
+            ml: false,
+        }
+    }
+}
+
+impl PackageToggles {
+    /// Registers the selected packages with the provided `Engine` instance.
+    pub fn apply_to_engine(&self, engine: &mut rhai::Engine) {
+        if self.sci {
+            engine.register_global_module(SciPackage::new().as_shared_module());
+        }
+
+        if self.ml {
+            engine.register_global_module(MLPackage::new().as_shared_module());
+        }
+    }
+
+    /// Updates the toggles using a list of selected package names.
+    pub fn update_from_selection(&mut self, selected: &[String]) {
+        let normalized: Vec<String> = selected
+            .iter()
+            .map(|name| name.trim().to_lowercase())
+            .collect();
+
+        self.sci = normalized.iter().any(|name| name == "rhai-sci");
+        self.ml = normalized.iter().any(|name| name == "rhai-ml");
+    }
+
+    /// Returns the currently selected packages.
+    #[must_use]
+    pub fn selected_packages(&self) -> Vec<String> {
+        let mut packages = Vec::new();
+        if self.sci {
+            packages.push("rhai-sci".to_string());
+        }
+
+        if self.ml {
+            packages.push("rhai-ml".to_string());
+        }
+
+        packages
+    }
+
+    /// Indicates whether the scientific utilities package is enabled.
+    #[must_use]
+    pub fn sci(&self) -> bool {
+        self.sci
+    }
+
+    /// Indicates whether the machine learning package is enabled.
+    #[must_use]
+    pub fn ml(&self) -> bool {
+        self.ml
+    }
+}
+
+/// Describes an optional Rhai package that can be toggled in the UI.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PackageDescriptor {
+    pub name: String,
+    pub description: String,
+    pub repository: String,
+    pub selected: bool,
+}
+
+/// Executes a Rhai script and forwards every emitted message to the provided
+/// sink.
+///
+/// Messages include anything produced by the script via `print` as well as the
+/// final return value or runtime error.
+///
+/// # Examples
+/// ```
+/// use app::{run_rhai_script_with_sink, OutputSink, PackageToggles};
+/// use std::sync::{Arc, Mutex};
+///
+/// let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+/// let sink_output = Arc::clone(&captured);
+/// let sink: OutputSink = Arc::new(move |message| {
+///     sink_output
+///         .lock()
+///         .expect("failed to capture script output")
+///         .push(message);
+/// });
+///
+/// run_rhai_script_with_sink("40 + 2", &sink, &PackageToggles::default());
+/// assert_eq!(captured.lock().unwrap().as_slice(), ["42"]);
+/// ```
+pub fn run_rhai_script_with_sink(script: &str, sink: &OutputSink, packages: &PackageToggles) {
+    let mut engine = rhai::Engine::new();
+    packages.apply_to_engine(&mut engine);
+
+    let print_sink = Arc::clone(sink);
+    engine.on_print(move |x| {
+        print_sink(x.to_string());
+    });
+
+    match engine.compile(script) {
+        Ok(script_ast) => match engine.eval_ast::<rhai::Dynamic>(&script_ast) {
+            Ok(result) => sink(result.to_string()),
+            Err(e) => sink(format!("{e:?}")),
+        },
+        Err(e) => sink(e.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{append_output_script, run_rhai_script_with_sink, OutputSink, PackageToggles};
+    use std::sync::{Arc, Mutex};
+
+    fn run_script_with_collector(script: &str, packages: &PackageToggles) -> Vec<String> {
+        let captured_output: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_target = Arc::clone(&captured_output);
+        let sink: OutputSink = Arc::new(move |message: String| {
+            sink_target
+                .lock()
+                .expect("collector mutex poisoned")
+                .push(message);
+        });
+
+        run_rhai_script_with_sink(script, &sink, packages);
+
+        let collected = captured_output
+            .lock()
+            .expect("collector mutex poisoned")
+            .clone();
+
+        collected
+    }
+
+    #[test]
+    fn append_output_script_serializes_control_characters() {
+        let result = append_output_script("Line 1\nLine 2\tTabbed")
+            .expect("failed to serialize message with control characters");
+        assert_eq!(result, "append_output(\"Line 1\\nLine 2\\tTabbed\")");
+    }
+
+    #[test]
+    fn append_output_script_preserves_quotes_and_unicode() {
+        let result = append_output_script("He said, \"hi\" ☃")
+            .expect("failed to serialize message with quotes and unicode");
+        assert_eq!(result, "append_output(\"He said, \\\"hi\\\" ☃\")");
+    }
+
+    #[test]
+    fn invalid_script_reports_parse_error() {
+        let default_packages = PackageToggles::default();
+        let output = run_script_with_collector("let x = ;", &default_packages);
+        let last_message = output
+            .last()
+            .expect("missing output entry for invalid script");
+
+        assert!(
+            last_message.contains("Unexpected"),
+            "expected parse error message, got: {last_message}",
+        );
+    }
+
+    #[test]
+    fn valid_script_reports_result() {
+        let default_packages = PackageToggles::default();
+        let output = run_script_with_collector("40 + 2", &default_packages);
+        assert!(
+            output.contains(&"42".to_string()),
+            "expected valid script to produce \"42\" but saw {output:?}",
+        );
+    }
+
+    #[test]
+    fn runtime_errors_are_forwarded_to_the_sink() {
+        let default_packages = PackageToggles::default();
+        let output = run_script_with_collector(
+            r#"
+            fn explode() { throw("boom"); }
+            explode();
+            "#,
+            &default_packages,
+        );
+
+        let last_message = output
+            .last()
+            .expect("missing output entry for runtime error");
+        assert!(
+            last_message.contains("boom"),
+            "expected runtime error payload, got: {last_message}",
+        );
+    }
+
+    #[test]
+    fn print_statements_are_captured_before_results() {
+        let default_packages = PackageToggles::default();
+        let output = run_script_with_collector(r#"print("hi"); 41 + 1;"#, &default_packages);
+
+        assert_eq!(
+            output,
+            vec!["hi".to_string(), "42".to_string()],
+            "expected print output to precede the result",
+        );
+    }
+
+    #[test]
+    fn package_selection_can_toggle_sci_and_ml_modules() {
+        let mut packages = PackageToggles::default();
+        assert!(packages.sci(), "sci should be enabled by default");
+        assert!(!packages.ml(), "ml should be disabled by default");
+
+        packages.update_from_selection(&["rhai-ml".to_string()]);
+
+        assert!(
+            !packages.sci(),
+            "updating selection without rhai-sci should disable the sci package",
+        );
+        assert!(
+            packages.ml(),
+            "updating selection with rhai-ml should enable the ml package",
+        );
+
+        assert_eq!(packages.selected_packages(), vec!["rhai-ml".to_string()]);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,10 +58,14 @@ impl PackageToggles {
     }
 
     /// Updates the toggles using a list of selected package names.
-    pub fn update_from_selection(&mut self, selected: &[String]) {
+    pub fn update_from_selection<I, S>(&mut self, selected: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
         let normalized: Vec<String> = selected
-            .iter()
-            .map(|name| name.trim().to_lowercase())
+            .into_iter()
+            .map(|name| name.as_ref().trim().to_lowercase())
             .collect();
 
         self.sci = normalized.iter().any(|name| name == "rhai-sci");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,357 +2,166 @@
     all(not(debug_assertions), target_os = "windows"),
     windows_subsystem = "windows"
 )]
-use std::sync::{Arc, Mutex};
 
-use serde::Serialize;
-
-/// Builds a JavaScript snippet that safely forwards a message to the frontend.
-///
-/// The message is serialized using `serde_json` so that newline characters,
-/// quotes, and other special characters remain valid once evaluated in the
-/// webview.
-///
-/// # Examples
-/// ```rust,ignore
-/// let script = append_output_script("Hello\nworld").unwrap();
-/// assert_eq!(script, "append_output(\"Hello\\nworld\")");
-/// ```
-fn append_output_script(message: &str) -> Result<String, serde_json::Error> {
-    serde_json::to_string(message).map(|escaped| format!("append_output({escaped})"))
-}
-
-fn send_output(window: &tauri::Window, message: &str) {
-    match append_output_script(message) {
-        Ok(script) => {
-            if let Err(eval_error) = window.eval(&script) {
-                eprintln!("failed to evaluate output script: {eval_error}");
-            }
-        }
-        Err(serialize_error) => {
-            eprintln!("failed to serialize output message {message:?}: {serialize_error}");
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct PackageToggles {
-    sci: bool,
-    ml: bool,
-}
-
-impl Default for PackageToggles {
-    fn default() -> Self {
-        Self {
-            sci: true,
-            ml: false,
-        }
-    }
-}
-
-impl PackageToggles {
-    fn apply_to_engine(&self, engine: &mut rhai::Engine) {
-        if self.sci {
-            engine.register_global_module(SciPackage::new().as_shared_module());
-        }
-
-        if self.ml {
-            engine.register_global_module(MLPackage::new().as_shared_module());
-        }
-    }
-
-    fn update_from_selection(&mut self, selected: &[String]) {
-        let normalized: Vec<String> = selected
-            .iter()
-            .map(|name| name.trim().to_lowercase())
-            .collect();
-
-        self.sci = normalized.iter().any(|name| name == "rhai-sci");
-        self.ml = normalized.iter().any(|name| name == "rhai-ml");
-    }
-
-    fn selected_packages(&self) -> Vec<String> {
-        let mut packages = Vec::new();
-        if self.sci {
-            packages.push("rhai-sci".to_string());
-        }
-
-        if self.ml {
-            packages.push("rhai-ml".to_string());
-        }
-
-        packages
-    }
-}
-
-#[derive(Serialize)]
-struct PackageDescriptor {
-    name: String,
-    description: String,
-    repository: String,
-    selected: bool,
-}
-
-struct MyState {
-    engine: Mutex<rhai::Engine>,
-    scope: Mutex<rhai::Scope<'static>>,
-    packages: Mutex<PackageToggles>,
-}
-
-fn main() {
-    let packages = PackageToggles::default();
-    let mut engine = rhai::Engine::new();
-    packages.apply_to_engine(&mut engine);
-    let scope = rhai::Scope::new();
-
-    tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![
-            rhai_repl,
-            rhai_script,
-            list_available_packages,
-            update_packages
-        ])
-        .manage(MyState {
-            engine: Mutex::new(engine),
-            scope: Mutex::new(scope),
-            packages: Mutex::new(packages),
-        })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
-}
-
-use rhai::packages::Package;
-use rhai_ml::MLPackage;
-use rhai_sci::SciPackage;
-
-#[tauri::command]
-fn rhai_script(script: &str, window: tauri::Window, state: tauri::State<MyState>) {
-    let output_sink: OutputSink = Arc::new(move |message: String| {
-        send_output(&window, &message);
-    });
-
-    let selected_packages = state
-        .packages
-        .lock()
-        .expect("package mutex poisoned")
-        .clone();
-
-    run_rhai_script_with_sink(script, &output_sink, &selected_packages);
-}
-
-#[allow(clippy::needless_pass_by_value)]
-#[tauri::command]
-fn rhai_repl(script: &str, window: tauri::Window, state: tauri::State<MyState>) {
-    let mut engine = state.engine.lock().unwrap();
-    let mut scope = state.scope.lock().unwrap();
-    let window_for_print = window.clone();
-    engine.on_print(move |message| {
-        send_output(&window_for_print, message);
-    });
-
-    match engine.eval_with_scope::<rhai::Dynamic>(&mut scope, script) {
-        Ok(result) => send_output(&window, &result.to_string()),
-        Err(e) => send_output(&window, &format!("{e:?}")),
-    }
-}
-
-type OutputSink = Arc<dyn Fn(String) + Send + Sync + 'static>;
-
-/// Executes a Rhai script and forwards every emitted message to the provided
-/// sink.
-///
-/// Messages include anything produced by the script via `print` as well as the
-/// final return value or runtime error.
-///
-/// # Examples
-/// ```rust,ignore
-/// let output = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-/// let sink_output = std::sync::Arc::clone(&output);
-/// let sink: OutputSink = std::sync::Arc::new(move |message: String| {
-///     sink_output
-///         .lock()
-///         .expect("failed to capture script output")
-///         .push(message);
-/// });
-///
-/// run_rhai_script_with_sink("40 + 2", &sink);
-/// assert_eq!(output.lock().unwrap().as_slice(), ["42"]);
-/// ```
-fn run_rhai_script_with_sink(script: &str, sink: &OutputSink, packages: &PackageToggles) {
-    let mut engine = rhai::Engine::new();
-    packages.apply_to_engine(&mut engine);
-
-    let print_sink = Arc::clone(sink);
-    engine.on_print(move |x| {
-        print_sink(x.to_string());
-    });
-
-    match engine.compile(script) {
-        Ok(script_ast) => match engine.eval_ast::<rhai::Dynamic>(&script_ast) {
-            Ok(result) => sink(result.to_string()),
-            Err(e) => sink(format!("{:?}", e)),
-        },
-        Err(e) => sink(e.to_string()),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{append_output_script, run_rhai_script_with_sink, OutputSink, PackageToggles};
+#[cfg(feature = "desktop")]
+mod desktop {
     use std::sync::{Arc, Mutex};
 
-    fn run_script_with_collector(script: &str, packages: PackageToggles) -> Vec<String> {
-        let captured_output: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-        let sink_target = Arc::clone(&captured_output);
-        let sink: OutputSink = Arc::new(move |message: String| {
-            sink_target
-                .lock()
-                .expect("collector mutex poisoned")
-                .push(message);
+    use app::{
+        append_output_script, run_rhai_script_with_sink, OutputSink, PackageDescriptor,
+        PackageToggles,
+    };
+    use serde::Serialize;
+    use tauri::State;
+
+    pub struct MyState {
+        engine: Mutex<rhai::Engine>,
+        scope: Mutex<rhai::Scope<'static>>,
+        packages: Mutex<PackageToggles>,
+    }
+
+    pub fn run_application() {
+        let packages = PackageToggles::default();
+        let mut engine = rhai::Engine::new();
+        packages.apply_to_engine(&mut engine);
+        let scope = rhai::Scope::new();
+
+        tauri::Builder::default()
+            .invoke_handler(tauri::generate_handler![
+                rhai_repl,
+                rhai_script,
+                list_available_packages,
+                update_packages
+            ])
+            .manage(MyState {
+                engine: Mutex::new(engine),
+                scope: Mutex::new(scope),
+                packages: Mutex::new(packages),
+            })
+            .run(tauri::generate_context!())
+            .expect("error while running tauri application");
+    }
+
+    fn send_output(window: &tauri::Window, message: &str) {
+        match append_output_script(message) {
+            Ok(script) => {
+                if let Err(eval_error) = window.eval(&script) {
+                    eprintln!("failed to evaluate output script: {eval_error}");
+                }
+            }
+            Err(serialize_error) => {
+                eprintln!("failed to serialize output message {message:?}: {serialize_error}");
+            }
+        }
+    }
+
+    #[tauri::command]
+    fn rhai_script(script: &str, window: tauri::Window, state: State<MyState>) {
+        let output_sink: OutputSink = Arc::new(move |message: String| {
+            send_output(&window, &message);
         });
 
-        run_rhai_script_with_sink(script, &sink, &packages);
-
-        let collected = captured_output
+        let selected_packages = state
+            .packages
             .lock()
-            .expect("collector mutex poisoned")
+            .expect("package mutex poisoned")
             .clone();
 
-        collected
+        run_rhai_script_with_sink(script, &output_sink, &selected_packages);
     }
 
-    #[test]
-    fn append_output_script_serializes_control_characters() {
-        let result = append_output_script("Line 1\nLine 2\tTabbed")
-            .expect("failed to serialize message with control characters");
-        assert_eq!(result, "append_output(\"Line 1\\nLine 2\\tTabbed\")");
+    #[allow(clippy::needless_pass_by_value)]
+    #[tauri::command]
+    fn rhai_repl(script: &str, window: tauri::Window, state: State<MyState>) {
+        let mut engine = state.engine.lock().expect("engine mutex poisoned");
+        let mut scope = state.scope.lock().expect("scope mutex poisoned");
+        let window_for_print = window.clone();
+        engine.on_print(move |message| {
+            send_output(&window_for_print, message);
+        });
+
+        match engine.eval_with_scope::<rhai::Dynamic>(&mut scope, script) {
+            Ok(result) => send_output(&window, &result.to_string()),
+            Err(error) => send_output(&window, &format!("{error:?}")),
+        }
     }
 
-    #[test]
-    fn append_output_script_preserves_quotes_and_unicode() {
-        let result = append_output_script("He said, \"hi\" ☃")
-            .expect("failed to serialize message with quotes and unicode");
-        assert_eq!(result, "append_output(\"He said, \\\"hi\\\" ☃\")");
+    #[derive(Serialize)]
+    struct SerializablePackageDescriptor {
+        name: String,
+        description: String,
+        repository: String,
+        selected: bool,
     }
 
-    #[test]
-    fn invalid_script_reports_parse_error() {
-        let output = run_script_with_collector("let x = ;", PackageToggles::default());
-        let last_message = output
-            .last()
-            .expect("missing output entry for invalid script");
+    #[tauri::command]
+    fn list_available_packages(state: State<MyState>) -> Vec<SerializablePackageDescriptor> {
+        let selected = state
+            .packages
+            .lock()
+            .expect("package mutex poisoned")
+            .clone();
 
-        assert!(
-            last_message.contains("Unexpected"),
-            "expected parse error message, got: {last_message}",
-        );
+        build_package_descriptors(&selected)
+            .into_iter()
+            .map(|descriptor| SerializablePackageDescriptor {
+                name: descriptor.name,
+                description: descriptor.description,
+                repository: descriptor.repository,
+                selected: descriptor.selected,
+            })
+            .collect()
     }
 
-    #[test]
-    fn valid_script_reports_result() {
-        let output = run_script_with_collector("40 + 2", PackageToggles::default());
-        assert!(
-            output.contains(&"42".to_string()),
-            "expected valid script to produce \"42\" but saw {output:?}",
-        );
+    fn build_package_descriptors(selected: &PackageToggles) -> Vec<PackageDescriptor> {
+        vec![
+            PackageDescriptor {
+                name: "rhai-sci".to_string(),
+                description: "Scientific and numerical utilities built on smartcore and nalgebra"
+                    .to_string(),
+                repository: "https://github.com/rhaiscript/rhai-sci".to_string(),
+                selected: selected.sci(),
+            },
+            PackageDescriptor {
+                name: "rhai-ml".to_string(),
+                description: "Machine learning helpers for Rhai scripts".to_string(),
+                repository: "https://github.com/rhaiscript/rhai-ml".to_string(),
+                selected: selected.ml(),
+            },
+        ]
     }
 
-    #[test]
-    fn runtime_errors_are_forwarded_to_the_sink() {
-        let output = run_script_with_collector(
-            r#"
-            fn explode() { throw("boom"); }
-            explode();
-            "#,
-            PackageToggles::default(),
-        );
+    #[tauri::command]
+    fn update_packages(selected: Vec<String>, state: State<MyState>) {
+        let mut package_state = state.packages.lock().expect("package mutex poisoned");
 
-        let last_message = output
-            .last()
-            .expect("missing output entry for runtime error");
-        assert!(
-            last_message.contains("boom"),
-            "expected runtime error payload, got: {last_message}",
-        );
-    }
+        let mut new_selection = package_state.clone();
+        new_selection.update_from_selection(&selected);
 
-    #[test]
-    fn print_statements_are_captured_before_results() {
-        let output =
-            run_script_with_collector(r#"print("hi"); 41 + 1;"#, PackageToggles::default());
+        if *package_state == new_selection {
+            return;
+        }
 
-        assert_eq!(
-            output,
-            vec!["hi".to_string(), "42".to_string()],
-            "expected print output to precede the result"
-        );
-    }
+        *package_state = new_selection.clone();
 
-    #[test]
-    fn package_selection_can_toggle_sci_and_ml_modules() {
-        let mut packages = PackageToggles::default();
-        assert!(packages.sci, "sci should be enabled by default");
-        assert!(!packages.ml, "ml should be disabled by default");
+        let mut engine = state.engine.lock().expect("engine mutex poisoned");
+        *engine = {
+            let mut refreshed = rhai::Engine::new();
+            new_selection.apply_to_engine(&mut refreshed);
+            refreshed
+        };
 
-        packages.update_from_selection(&["rhai-ml".to_string()]);
-
-        assert!(
-            !packages.sci,
-            "updating selection without rhai-sci should disable the sci package"
-        );
-        assert!(
-            packages.ml,
-            "updating selection with rhai-ml should enable the ml package"
-        );
-
-        assert_eq!(packages.selected_packages(), vec!["rhai-ml".to_string()]);
+        let mut scope = state.scope.lock().expect("scope mutex poisoned");
+        *scope = rhai::Scope::new();
     }
 }
 
-#[tauri::command]
-fn list_available_packages(state: tauri::State<MyState>) -> Vec<PackageDescriptor> {
-    let selected = state
-        .packages
-        .lock()
-        .expect("package mutex poisoned")
-        .clone();
-
-    vec![
-        PackageDescriptor {
-            name: "rhai-sci".to_string(),
-            description: "Scientific and numerical utilities built on smartcore and nalgebra"
-                .to_string(),
-            repository: "https://github.com/rhaiscript/rhai-sci".to_string(),
-            selected: selected.sci,
-        },
-        PackageDescriptor {
-            name: "rhai-ml".to_string(),
-            description: "Machine learning helpers for Rhai scripts".to_string(),
-            repository: "https://github.com/rhaiscript/rhai-ml".to_string(),
-            selected: selected.ml,
-        },
-    ]
+#[cfg(feature = "desktop")]
+fn main() {
+    desktop::run_application();
 }
 
-#[tauri::command]
-fn update_packages(selected: Vec<String>, state: tauri::State<MyState>) {
-    let mut package_state = state.packages.lock().expect("package mutex poisoned");
-
-    let mut new_selection = package_state.clone();
-    new_selection.update_from_selection(&selected);
-
-    if *package_state == new_selection {
-        return;
-    }
-
-    *package_state = new_selection.clone();
-
-    let mut engine = state.engine.lock().unwrap();
-    *engine = {
-        let mut refreshed = rhai::Engine::new();
-        new_selection.apply_to_engine(&mut refreshed);
-        refreshed
-    };
-
-    let mut scope = state.scope.lock().unwrap();
-    *scope = rhai::Scope::new();
+#[cfg(not(feature = "desktop"))]
+fn main() {
+    eprintln!("The `desktop` feature is required to run the Tauri UI.");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -56,7 +56,7 @@ mod desktop {
     }
 
     #[tauri::command]
-    fn rhai_script(script: &str, window: tauri::Window, state: State<MyState>) {
+    fn rhai_script(script: &str, window: tauri::Window, state: State<'_, MyState>) {
         let output_sink: OutputSink = Arc::new(move |message: String| {
             send_output(&window, &message);
         });
@@ -70,9 +70,8 @@ mod desktop {
         run_rhai_script_with_sink(script, &output_sink, &selected_packages);
     }
 
-    #[allow(clippy::needless_pass_by_value)]
     #[tauri::command]
-    fn rhai_repl(script: &str, window: tauri::Window, state: State<MyState>) {
+    fn rhai_repl(script: &str, window: tauri::Window, state: State<'_, MyState>) {
         let mut engine = state.engine.lock().expect("engine mutex poisoned");
         let mut scope = state.scope.lock().expect("scope mutex poisoned");
         let window_for_print = window.clone();
@@ -95,7 +94,7 @@ mod desktop {
     }
 
     #[tauri::command]
-    fn list_available_packages(state: State<MyState>) -> Vec<SerializablePackageDescriptor> {
+    fn list_available_packages(state: State<'_, MyState>) -> Vec<SerializablePackageDescriptor> {
         let selected = state
             .packages
             .lock()
@@ -132,11 +131,11 @@ mod desktop {
     }
 
     #[tauri::command]
-    fn update_packages(selected: Vec<String>, state: State<MyState>) {
+    fn update_packages(selected: Vec<String>, state: State<'_, MyState>) {
         let mut package_state = state.packages.lock().expect("package mutex poisoned");
 
         let mut new_selection = package_state.clone();
-        new_selection.update_from_selection(&selected);
+        new_selection.update_from_selection(selected);
 
         if *package_state == new_selection {
             return;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,7 +3,7 @@
     windows_subsystem = "windows"
 )]
 
-#[cfg(feature = "desktop")]
+#[cfg(feature = "custom-protocol")]
 mod desktop {
     use std::sync::{Arc, Mutex};
 
@@ -156,12 +156,12 @@ mod desktop {
     }
 }
 
-#[cfg(feature = "desktop")]
+#[cfg(feature = "custom-protocol")]
 fn main() {
     desktop::run_application();
 }
 
-#[cfg(not(feature = "desktop"))]
+#[cfg(not(feature = "custom-protocol"))]
 fn main() {
-    eprintln!("The `desktop` feature is required to run the Tauri UI.");
+    eprintln!("Enable the `desktop` (or `custom-protocol`) feature to run the Tauri UI.");
 }


### PR DESCRIPTION
## Summary
- extract the Rhai scripting utilities into a reusable library module with unit and doc tests
- gate the Tauri runtime behind a new optional `desktop` feature and provide a headless fallback main
- document the new workflow and feature flags so builds and tests run without GTK/WebKit dependencies

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings -W clippy::pedantic
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e0591fe9088325ac744c2f6b15e287