### PR TITLE
Add bundled Rhai packages to settings modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,17 +65,17 @@ npm run tauri
 
 This will build the frontend, compile the Rust backend, and open the desktop shell with hot-reload enabled.
 
-## Loading Rhai community packages
+## Bundled Rhai packages
 
-Open the **Settings** button in the upper-right corner of the interface to load additional Rhai packages at runtime. The
-modal lists the curated [`rhaiscript`](https://github.com/orgs/rhaiscript/repositories?type=all) packages bundled with the
-application:
+Pastrami preloads the curated [`rhaiscript`](https://github.com/orgs/rhaiscript/repositories?type=all) packages directly
+into the Rhai engine so their APIs are always available without visiting a settings modal. Each package is exposed through
+its own namespace to avoid polluting the global scope:
 
-- [`rhai-sci`](https://github.com/rhaiscript/rhai-sci) — scientific and numerical helpers
-- [`rhai-ml`](https://github.com/rhaiscript/rhai-ml) — machine learning helpers
-- [`rhai-fs`](https://github.com/rhaiscript/rhai-fs) — filesystem access helpers
-- [`rhai-url`](https://github.com/rhaiscript/rhai-url) — URL parsing and manipulation helpers
-- [`rhai-rand`](https://github.com/rhaiscript/rhai-rand) — random number generation helpers
+- [`sci`](https://github.com/rhaiscript/rhai-sci) wraps the scientific helpers from `rhai-sci`
+- [`ml`](https://github.com/rhaiscript/rhai-ml) provides machine learning utilities from `rhai-ml`
+- [`fs`](https://github.com/rhaiscript/rhai-fs) offers filesystem helpers from `rhai-fs`
+- [`url`](https://github.com/rhaiscript/rhai-url) exposes URL parsing and manipulation helpers from `rhai-url`
+- [`rand`](https://github.com/rhaiscript/rhai-rand) supplies random number generation helpers from `rhai-rand`
 
-Enable the checkboxes for any combination of packages to register their APIs in the interactive REPL and one-off script
-runner without restarting the app. Clearing all checkboxes reverts to the base Rhai engine.
+Call functions with the namespace prefix—for example `rand::rand(0, 10)` to generate a random integer. The REPL and
+script runner share this configuration, so scripts have access to the same modules by default.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ This will build the frontend, compile the Rust backend, and open the desktop she
 
 Open the **Settings** button in the upper-right corner of the interface to load additional Rhai packages at runtime. The
 modal lists the curated [`rhaiscript`](https://github.com/orgs/rhaiscript/repositories?type=all) packages bundled with the
-application. Enable the checkboxes for [`rhai-sci`](https://github.com/rhaiscript/rhai-sci) or
-[`rhai-ml`](https://github.com/rhaiscript/rhai-ml) to register their APIs in the interactive REPL and one-off script runner
-without restarting the app. Clearing all checkboxes reverts to the base Rhai engine.
+application:
+
+- [`rhai-sci`](https://github.com/rhaiscript/rhai-sci) — scientific and numerical helpers
+- [`rhai-ml`](https://github.com/rhaiscript/rhai-ml) — machine learning helpers
+- [`rhai-fs`](https://github.com/rhaiscript/rhai-fs) — filesystem access helpers
+- [`rhai-url`](https://github.com/rhaiscript/rhai-url) — URL parsing and manipulation helpers
+- [`rhai-rand`](https://github.com/rhaiscript/rhai-rand) — random number generation helpers
+
+Enable the checkboxes for any combination of packages to register their APIs in the interactive REPL and one-off script
+runner without restarting the app. Clearing all checkboxes reverts to the base Rhai engine.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ the application or its test suite:
   ```bash
   sudo apt-get update
   sudo apt-get install -y \
-    libwebkit2gtk-4.0-dev \
+    libwebkit2gtk-4.1-dev \
     libgtk-3-dev \
     libayatana-appindicator3-dev \
     librsvg2-dev \
@@ -27,9 +27,10 @@ the application or its test suite:
   can be produced. The Tauri bundler will also use the system `codesign` binary during `npm run tauri build`.
 
 > [!NOTE]
-> Ubuntu 24.04 currently publishes WebKitGTK 4.1. When developing on that release you may need to provide compatibility
-> symlinks (`libwebkit2gtk-4.0.so`, `libjavascriptcoregtk-4.0.so`, and their corresponding `.pc` files) that forward to the
-> installed 4.1 libraries so that older Tauri versions link successfully.
+> Ubuntu 24.04 publishes WebKitGTK 4.1. The bundled Tauri backend links against the same version, so the development
+> dependencies above install `libwebkit2gtk-4.1-dev` and `libjavascriptcoregtk-4.1-dev`. If you are building on an older
+> distribution that only ships WebKitGTK 4.0 you can still compile the application, but cross-version builds are not
+> supported.
 
 ## Development workflow
 
@@ -71,7 +72,8 @@ Pastrami preloads the curated [`rhaiscript`](https://github.com/orgs/rhaiscript/
 into the Rhai engine so their APIs are always available without visiting a settings modal. Each package is exposed through
 its own namespace to avoid polluting the global scope:
 
-- [`sci`](https://github.com/rhaiscript/rhai-sci) wraps the scientific helpers from `rhai-sci`
+- [`sci`](https://github.com/rhaiscript/rhai-sci) wraps the scientific helpers from `rhai-sci` (matrix algebra, statistics,
+  and modelling powered by the `nalgebra`, `smartcore`, and `rand` feature set)
 - [`ml`](https://github.com/rhaiscript/rhai-ml) provides machine learning utilities from `rhai-ml`
 - [`fs`](https://github.com/rhaiscript/rhai-fs) offers filesystem helpers from `rhai-fs`
 - [`url`](https://github.com/rhaiscript/rhai-url) exposes URL parsing and manipulation helpers from `rhai-url`
@@ -79,3 +81,7 @@ its own namespace to avoid polluting the global scope:
 
 Call functions with the namespace prefix—for example `rand::rand(0, 10)` to generate a random integer. The REPL and
 script runner share this configuration, so scripts have access to the same modules by default.
+
+The curated scientific namespace intentionally omits the optional CSV/file helpers from `rhai-sci`'s `io` feature so the Tauri
+bundle remains portable across macOS and Linux. Combine the `sci` tools with the dedicated `fs` namespace whenever a script
+needs filesystem access.

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,11 +13,6 @@
     </style>
 </head>
 <body style="background-color: black">
-<div class="position-absolute" style="right: 1rem; top: 1rem; z-index: 1030;">
-    <button type="button" class="btn btn-outline-light btn-sm" data-toggle="modal" data-target="#settingsModal">
-        Settings
-    </button>
-</div>
 <div class="container-fluid h-100 min-vh-100 p-0">
     <div class="row w-100 m-0" id="output_holder" >
         <div class="col h-100 min-vh-100 "style="background-color: #2B2B2B;">
@@ -27,30 +22,6 @@
                   style="white-space: pre-wrap; line-height: 25px;">&gt;&gt;&gt; </code>
             <code id="repl_input" class="text-warning d-inline pb-0 w-100"
                   style="min-height: 1em; white-space: pre-wrap; min-width: 3em; margin-left: -4px; line-height: 25px;" contenteditable></code>
-        </div>
-    </div>
-</div>
-<div class="modal fade" id="settingsModal" tabindex="-1" role="dialog" aria-labelledby="settingsModalTitle"
-     aria-hidden="true">
-    <div class="modal-dialog modal-dialog-scrollable" role="document">
-        <div class="modal-content bg-dark text-light">
-            <div class="modal-header border-secondary">
-                <h5 class="modal-title" id="settingsModalTitle">Rhai Packages</h5>
-                <button type="button" class="close text-light" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body" id="packageList">
-                <p class="text-muted mb-0">Loading available packages…</p>
-            </div>
-            <div class="modal-footer border-secondary">
-                <a class="mr-auto text-info" href="https://github.com/orgs/rhaiscript/repositories?type=all"
-                   target="_blank" rel="noreferrer noopener">
-                    Explore Rhai community packages
-                </a>
-                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-primary" id="savePackageSelection">Load Packages</button>
-            </div>
         </div>
     </div>
 </div>
@@ -124,75 +95,6 @@
             textRange.moveStart('character', textLength);
             textRange.select();
         }
-    }
-
-    const packageModal = document.getElementById("settingsModal");
-    const packageList = document.getElementById("packageList");
-    const packageSaveButton = document.getElementById("savePackageSelection");
-
-    packageModal.addEventListener('show.bs.modal', async () => {
-        packageList.innerHTML = '<p class="text-muted mb-0">Loading bundled packages…</p>';
-        try {
-            const packages = await invoke('list_available_packages');
-            renderPackageOptions(packages);
-        } catch (error) {
-            packageList.innerHTML = '';
-            append_output(`#Failed to load packages: ${error}`);
-        }
-    });
-
-    packageSaveButton.addEventListener('click', async () => {
-        const selected = Array.from(
-            packageList.querySelectorAll('input.package-checkbox:checked')
-        ).map((checkbox) => checkbox.value);
-
-        try {
-            await invoke('update_packages', {selected});
-            const summary = selected.length > 0 ? selected.join(', ') : 'none';
-            append_output(`Loaded packages: ${summary}`);
-            if (window.jQuery) {
-                window.jQuery(packageModal).modal('hide');
-            }
-        } catch (error) {
-            append_output(`#Failed to update packages: ${error}`);
-        }
-    });
-
-    function escapeHtml(value) {
-        if (typeof value !== 'string') {
-            return '';
-        }
-
-        return value
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
-    }
-
-    function renderPackageOptions(packages) {
-        if (!Array.isArray(packages) || packages.length === 0) {
-            packageList.innerHTML = '<p class="text-muted mb-0">No bundled packages found.</p>';
-            return;
-        }
-
-        packageList.innerHTML = packages.map((pkg) => {
-            const checked = pkg.selected ? 'checked' : '';
-            const safeName = escapeHtml(pkg.name);
-            const safeDescription = escapeHtml(pkg.description);
-            const safeRepository = escapeHtml(pkg.repository);
-            return `
-                <div class="custom-control custom-checkbox mb-3">
-                    <input type="checkbox" class="custom-control-input package-checkbox" id="pkg-${safeName}" value="${safeName}" ${checked}>
-                    <label class="custom-control-label" for="pkg-${safeName}">
-                        <strong>${safeName}</strong>
-                        <span class="d-block text-muted small">${safeDescription}</span>
-                        <a class="text-info" href="${safeRepository}" target="_blank" rel="noreferrer noopener">${safeRepository}</a>
-                    </label>
-                </div>
-            `;
-        }).join('');
     }
 
     function append_output(payload) {

--- a/dist/index.html
+++ b/dist/index.html
@@ -131,7 +131,7 @@
     const packageSaveButton = document.getElementById("savePackageSelection");
 
     packageModal.addEventListener('show.bs.modal', async () => {
-        packageList.innerHTML = '<p class="text-muted mb-0">Loading available packages…</p>';
+        packageList.innerHTML = '<p class="text-muted mb-0">Loading bundled packages…</p>';
         try {
             const packages = await invoke('list_available_packages');
             renderPackageOptions(packages);
@@ -173,7 +173,7 @@
 
     function renderPackageOptions(packages) {
         if (!Array.isArray(packages) || packages.length === 0) {
-            packageList.innerHTML = '<p class="text-muted mb-0">No packages available.</p>';
+            packageList.innerHTML = '<p class="text-muted mb-0">No bundled packages found.</p>';
             return;
         }
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -61,15 +61,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,48 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "array-init-cursor"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed51fe0f224d1d4ea768be38c51f9f831dee9d05c163c11fba0b8c44387b1fc3"
-
-[[package]]
-name = "arrow-format"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07884ea216994cdc32a2d5f8274a8bee979cfe90274b83f86f440866ee3132c7"
-dependencies = [
- "planus",
- "serde",
-]
-
-[[package]]
-name = "arrow2"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4c5b03335bc1cb0fd9f5297f8fd3bbfd6fb04f3cb0bc7d6c91b7128cb8336a"
-dependencies = [
- "ahash",
- "arrow-format",
- "bytemuck",
- "chrono",
- "dyn-clone",
- "either",
- "ethnum",
- "foreign_vec",
- "getrandom 0.2.7",
- "hash_hasher",
- "lexical-core",
- "lz4",
- "multiversion",
- "num-traits",
- "rustc_version 0.4.0",
- "simdutf8",
- "strength_reduce",
- "zstd",
 ]
 
 [[package]]
@@ -268,10 +217,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
- "lazy_static",
  "memchr",
- "regex-automata 0.1.10",
- "serde",
 ]
 
 [[package]]
@@ -285,20 +231,6 @@ name = "bytemuck"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
 
 [[package]]
 name = "byteorder"
@@ -354,8 +286,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -398,19 +328,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
-]
 
 [[package]]
 name = "cocoa"
@@ -457,18 +374,6 @@ checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "comfy-table"
-version = "6.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e959d788268e3bf9d35ace83e81b124190378e4c91c9067524675e33394b8ba"
-dependencies = [
- "crossterm",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "unicode-width",
 ]
 
 [[package]]
@@ -567,31 +472,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "once_cell",
- "scopeguard",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,31 +479,6 @@ checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot 0.12.1",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -667,41 +522,6 @@ checksum = "dfae75de57f2b2e85e8768c3ea840fd159c8f33e2b6522c7835b7abac81be16e"
 dependencies = [
  "quote",
  "syn 1.0.99",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "csv-sniffer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e32aa93b952410d55c1ae03048cc22a6cc62a323711b8e9245ef4b5578051c"
-dependencies = [
- "bitflags 1.3.2",
- "csv",
- "csv-core",
- "memchr",
- "regex",
 ]
 
 [[package]]
@@ -809,15 +629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,17 +636,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -871,18 +671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "either"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
-
-[[package]]
 name = "embed-resource"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,18 +690,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
-name = "enum_dispatch"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "erased-serde"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,12 +699,6 @@ dependencies = [
  "serde_core",
  "typeid",
 ]
-
-[[package]]
-name = "ethnum"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
 name = "fastrand"
@@ -958,7 +728,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -997,12 +767,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "foreign_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1b05cbd864bcaecbd3455d6d967862d446e4ebfc3c2e5e5b9841e53cba6673"
 
 [[package]]
 name = "form_urlencoded"
@@ -1250,22 +1014,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1429,26 +1179,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash_hasher"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
- "rayon",
-]
 
 [[package]]
 name = "heck"
@@ -1504,19 +1238,6 @@ name = "http-range"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "js-sys",
- "wasm-bindgen",
- "winapi",
-]
 
 [[package]]
 name = "ico"
@@ -1583,7 +1304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1692,16 +1413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.3",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,79 +1451,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7aefb36fd43fef7003334742cbf77b243fcd36418a1d1bdd480d613a67968f6"
-dependencies = [
- "lexical-core",
-]
-
-[[package]]
-name = "lexical-core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-util"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,12 +1464,6 @@ checksum = "c185b5b7ad900923ef3a8ff594083d4d9b5aea80bb4f32b8342363138c0d456b"
 dependencies = [
  "pkg-config",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "line-wrap"
@@ -1883,25 +1515,6 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "lz4"
-version = "1.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
-dependencies = [
- "lz4-sys",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.11.1+lz4-1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -1977,15 +1590,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "memmap2"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,53 +1605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "minreq"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c785bc6027fd359756e538541c8624012ba3776d3d3fe123885643092ed4132"
-dependencies = [
- "lazy_static",
- "log",
- "rustls",
- "serde",
- "serde_json",
- "webpki",
- "webpki-roots",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "multiversion"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025c962a3dd3cc5e0e520aa9c612201d127dcdf28616974961a649dca64f5373"
-dependencies = [
- "multiversion-macros",
-]
-
-[[package]]
-name = "multiversion-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a3e2bde382ebf960c1f3e79689fa5941625fe9bf694a1cb64af3e85faff3af"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.99",
 ]
 
 [[package]]
@@ -2183,24 +1740,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "now"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d89e9874397a1f0a52fc1f197a8effd9735223cb2390e9dcc83ac6cd02923d0"
-dependencies = [
- "chrono",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,7 +1813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2372,7 +1910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23a407004a1033f53e93f9b45580d14de23928faad187384f891507c9b0c045"
 dependencies = [
  "pathdiff",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2474,37 +2012,12 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2517,7 +2030,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2665,15 +2178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "planus"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1691dd09e82f428ce8d6310bd6d5da2557c82ff17694d2a32cad7242aea89f"
-dependencies = [
- "array-init-cursor",
-]
-
-[[package]]
 name = "plist"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,185 +2213,6 @@ dependencies = [
  "crc32fast",
  "deflate 1.0.0",
  "miniz_oxide",
-]
-
-[[package]]
-name = "polars"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8918f4add49e6244bae2fe91cac89be339f2d6a77c59a4df3d7348bd40f98d1e"
-dependencies = [
- "getrandom 0.2.7",
- "polars-core",
- "polars-io",
- "polars-lazy",
- "polars-ops",
- "polars-time",
- "version_check",
-]
-
-[[package]]
-name = "polars-arrow"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e57a7b929edf6c73475dbc3f63d35152f14f4a9455476acc6127d770daa0f6"
-dependencies = [
- "arrow2",
- "hashbrown 0.13.2",
- "num",
- "thiserror",
-]
-
-[[package]]
-name = "polars-core"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a440cd53916f1a87fac1fda36cd7cc2d226247b4d4570d96242da5fa7f07b2a"
-dependencies = [
- "ahash",
- "anyhow",
- "arrow2",
- "bitflags 1.3.2",
- "chrono",
- "comfy-table",
- "hashbrown 0.13.2",
- "indexmap",
- "num",
- "once_cell",
- "polars-arrow",
- "polars-utils",
- "rand 0.8.5",
- "rand_distr",
- "rayon",
- "regex",
- "smartstring",
- "thiserror",
- "wasm-timer",
- "xxhash-rust",
-]
-
-[[package]]
-name = "polars-io"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d941750cba70a3acf150b959fcf446c09e8a8a4a35d03472d941bd6740bc43"
-dependencies = [
- "ahash",
- "anyhow",
- "arrow2",
- "bytes",
- "chrono",
- "dirs",
- "lexical",
- "lexical-core",
- "memchr",
- "memmap2",
- "num",
- "once_cell",
- "polars-arrow",
- "polars-core",
- "polars-time",
- "polars-utils",
- "rayon",
- "regex",
- "simdutf8",
-]
-
-[[package]]
-name = "polars-lazy"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d227fcb817485be462748d3172d2e55c61d56fbdc7fd56c24b72fa2e510e7be6"
-dependencies = [
- "ahash",
- "bitflags 1.3.2",
- "glob",
- "polars-arrow",
- "polars-core",
- "polars-io",
- "polars-ops",
- "polars-pipe",
- "polars-plan",
- "polars-time",
- "polars-utils",
- "rayon",
-]
-
-[[package]]
-name = "polars-ops"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36638340fd9f4377dab11f307877ebb5bdac3bc9b25ea32a771584de76e5280a"
-dependencies = [
- "arrow2",
- "polars-arrow",
- "polars-core",
- "polars-utils",
-]
-
-[[package]]
-name = "polars-pipe"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1dfae18a14a812119d3328dae8790be53f1bc0fbcb977606dcf0f181490a8f"
-dependencies = [
- "crossbeam-channel",
- "enum_dispatch",
- "hashbrown 0.13.2",
- "num",
- "polars-arrow",
- "polars-core",
- "polars-io",
- "polars-ops",
- "polars-plan",
- "polars-utils",
- "rayon",
- "smartstring",
-]
-
-[[package]]
-name = "polars-plan"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca57df4974f25fa0642ae18ef00c0836c5120d4371be77a34d4684173b043c3"
-dependencies = [
- "ahash",
- "once_cell",
- "polars-arrow",
- "polars-core",
- "polars-io",
- "polars-ops",
- "polars-time",
- "polars-utils",
- "rayon",
-]
-
-[[package]]
-name = "polars-time"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d961a9ccbe3c739de063fbf78449b3c172baf3379f958769c42ee9c309289786"
-dependencies = [
- "chrono",
- "lexical",
- "now",
- "once_cell",
- "polars-arrow",
- "polars-core",
- "polars-ops",
- "polars-utils",
- "regex",
-]
-
-[[package]]
-name = "polars-utils"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a741a3325c544c97c7a9ff57d857f089b60041bd92b06c41582df6940ffaa05b"
-dependencies = [
- "once_cell",
- "rayon",
- "sysinfo",
 ]
 
 [[package]]
@@ -2968,12 +2293,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,16 +2356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,30 +2387,6 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
-name = "rayon"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
-dependencies = [
- "autocfg",
- "crossbeam-deque",
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "num_cpus",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -3263,19 +2548,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d040e6a8d6e2dc8a0806fdac514dcafa0a41d96ba425e90d32711c60a182aec9"
 dependencies = [
  "bincode",
- "csv-sniffer",
  "linregress",
- "minreq",
  "nalgebra 0.32.6",
- "polars",
  "rand 0.8.5",
  "rhai",
  "serde",
  "serde_json",
  "smartcore",
  "smartstring",
- "temp-file",
- "url",
 ]
 
 [[package]]
@@ -3302,21 +2582,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3332,18 +2597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver 1.0.13",
-]
-
-[[package]]
-name = "rustls"
-version = "0.20.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
 ]
 
 [[package]]
@@ -3389,7 +2642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3403,16 +2656,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "security-framework"
@@ -3639,36 +2882,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "simba"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3693,12 +2906,6 @@ dependencies = [
  "paste",
  "wide",
 ]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "siphasher"
@@ -3803,12 +3010,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "strength_reduce"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ff2f71c82567c565ba4b3009a9350a96a7269eaa4001ebedae926230bc2254"
-
-[[package]]
 name = "string_cache"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3816,7 +3017,7 @@ checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
@@ -3846,14 +3047,8 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
 dependencies = [
- "strum_macros 0.22.0",
+ "strum_macros",
 ]
-
-[[package]]
-name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum_macros"
@@ -3864,19 +3059,6 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro2",
  "quote",
- "syn 1.0.99",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.0",
- "proc-macro2",
- "quote",
- "rustversion",
  "syn 1.0.99",
 ]
 
@@ -3900,20 +3082,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.27.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a902e9050fca0a5d6877550b769abd2bd1ce8c04634b941dbe2809735e1a1e33"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "winapi",
 ]
 
 [[package]]
@@ -3975,7 +3143,7 @@ dependencies = [
  "ndk-sys",
  "objc",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "paste",
  "png 0.17.5",
  "raw-window-handle",
@@ -4174,12 +3342,6 @@ dependencies = [
  "walkdir",
  "windows 0.37.0",
 ]
-
-[[package]]
-name = "temp-file"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4479870ee948e4c5c3fc4774b46aa73eedf97d84503a9b90922c1bb19a73a8d"
 
 [[package]]
 name = "tempfile"
@@ -4446,18 +3608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4571,24 +3721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4655,21 +3787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4724,25 +3841,6 @@ dependencies = [
  "pkg-config",
  "soup2-sys",
  "system-deps 6.0.2",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
-dependencies = [
- "webpki",
 ]
 
 [[package]]
@@ -4889,12 +3987,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-link"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
-
-[[package]]
 name = "windows-metadata"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4914,40 +4006,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
 name = "windows-tokens"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3263d25f1170419995b78ff10c06b949e8a986c35c208dc24333c64753a87169"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4966,12 +4028,6 @@ name = "windows_aarch64_msvc"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4998,12 +4054,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5026,12 +4076,6 @@ name = "windows_i686_msvc"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5058,18 +4102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5092,12 +4124,6 @@ name = "windows_x86_64_msvc"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winreg"
@@ -5123,16 +4149,10 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007a0353840b23e0c6dc73e5b962ff58ed7f6bc9ceff3ce7fe6fbad8d496edf4"
 dependencies = [
- "strum 0.22.0",
+ "strum",
  "windows 0.24.0",
  "xml-rs",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wry"
@@ -5201,38 +4221,3 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -89,8 +89,11 @@ name = "app"
 version = "0.1.0"
 dependencies = [
  "rhai",
+ "rhai-fs",
  "rhai-ml",
+ "rhai-rand",
  "rhai-sci",
+ "rhai-url",
  "serde",
  "serde_json",
  "tauri",
@@ -155,7 +158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3d816ce6f0e2909a96830d6911c2aff044370b1ef92d7f267b43bae5addedd"
 dependencies = [
  "atk-sys",
- "bitflags",
+ "bitflags 1.3.2",
  "glib",
  "libc",
 ]
@@ -216,6 +219,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "block"
@@ -309,7 +318,7 @@ version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c76ee391b03d35510d9fa917357c7f1855bd9a6659c95a1b392e33f49b3369bc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -409,7 +418,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f63902e9223530efb4e26ccd0cf55ec30d592d3b42e21a28defc42a9586e832"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "cocoa-foundation",
  "core-foundation",
@@ -425,7 +434,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-foundation",
  "core-graphics-types",
@@ -510,7 +519,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -523,7 +532,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "foreign-types",
  "libc",
@@ -598,7 +607,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -688,7 +697,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e32aa93b952410d55c1ae03048cc22a6cc62a323711b8e9245ef4b5578051c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "csv",
  "csv-core",
  "memchr",
@@ -1134,7 +1143,7 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e05c1f572ab0e1f15be94217f0dc29088c248b14f792a5ff0af0d84bcda9e8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "gdk-pixbuf",
  "gdk-sys",
@@ -1150,7 +1159,7 @@ version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38dd9cc8b099cceecdf41375bb6d481b1b5a7cd5cd603e10a69a9383f8619a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gdk-pixbuf-sys",
  "gio",
  "glib",
@@ -1265,7 +1274,7 @@ version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68fdbc90312d462781a395f7a16d96a2b379bb6ef8cd6310a2df272771c4283b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1295,7 +1304,7 @@ version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb0306fbad0ab5428b0ca674a23893db909a98582969c9b537be4ced78c505d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1371,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e3004a2d5d6d8b5057d2b57b3712c9529b62e82c77f25c1fecde1fd5c23bd0"
 dependencies = [
  "atk",
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "field-offset",
  "futures-channel",
@@ -1631,7 +1640,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf053e7843f2812ff03ef5afe34bb9c06ffee120385caad4f6b9967fcd37d41c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "glib",
  "javascriptcore-rs-sys",
 ]
@@ -2119,7 +2128,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2032c77e030ddee34a6787a64166008da93f6a352b629261d0fee232b8742dd4"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "jni-sys",
  "ndk-sys",
  "num_enum",
@@ -2146,6 +2155,15 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "nodrop"
@@ -2343,6 +2361,9 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "open"
@@ -2360,7 +2381,7 @@ version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2426,7 +2447,7 @@ version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e4045548659aee5313bde6c582b0d83a627b7904dd20dc2d9ef0895d414e4f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "glib",
  "libc",
  "once_cell",
@@ -2672,7 +2693,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0b0cabbbd20c2d7f06dbf015e06aad59b6ca3d9ed14848783e98af9aaf19925"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "deflate 0.7.20",
  "inflate",
  "num-iter",
@@ -2684,7 +2705,7 @@ version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc38c0ad57efb786dd57b9864e5b18bae478c00c824dc55a38bbc9da95dde3ba"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "deflate 1.0.0",
  "miniz_oxide",
@@ -2726,7 +2747,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "arrow2",
- "bitflags",
+ "bitflags 1.3.2",
  "chrono",
  "comfy-table",
  "hashbrown 0.13.2",
@@ -2779,7 +2800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d227fcb817485be462748d3172d2e55c61d56fbdc7fd56c24b72fa2e510e7be6"
 dependencies = [
  "ahash",
- "bitflags",
+ "bitflags 1.3.2",
  "glob",
  "polars-arrow",
  "polars-core",
@@ -2868,6 +2889,12 @@ dependencies = [
  "rayon",
  "sysinfo",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "ppv-lite86"
@@ -3082,7 +3109,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3176,17 +3203,31 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.9.0"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b85aefd80c317c18dc1bad3e6293602da1f8958dea2017f0d793dddfe69590"
+checksum = "13cfb72092d9bcb586d16188285b0b9b9e1c9098ea573d0266754f4b6eee5eb9"
 dependencies = [
  "ahash",
- "bitflags",
+ "bitflags 2.9.4",
  "instant",
+ "no-std-compat",
  "num-traits",
+ "once_cell",
  "rhai_codegen",
  "smallvec",
  "smartstring",
+ "thin-vec",
+]
+
+[[package]]
+name = "rhai-fs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af3f7717d7194033924473b3e4f0b3dbd569e3528837c3fbb00b4e1d1c6ff16"
+dependencies = [
+ "rhai",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3201,6 +3242,18 @@ dependencies = [
  "serde_json",
  "smartcore",
  "smartstring",
+]
+
+[[package]]
+name = "rhai-rand"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4314e7e2a1f5d5de224ae3bc9ce2af4c0146d07d3c3aadf9840f08d80ef28800"
+dependencies = [
+ "rand 0.8.5",
+ "rhai",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3226,14 +3279,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "rhai_codegen"
-version = "1.4.2"
+name = "rhai-url"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36791b0b801159db25130fd46ac726d2751c070260bba3a4a0a3eeb6231bb82a"
+checksum = "e2de48c06355410886a07e47691db696438b784788ef800ef7ca19ac78447964"
+dependencies = [
+ "rhai",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "rhai_codegen"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4322a2a4e8cf30771dd9f27f7f37ca9ac8fe812dddd811096a98483080dabe6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.99",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3355,7 +3420,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3378,7 +3443,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df320f1889ac4ba6bc0cdc9c9af7af4bd64bb927bccdf32d81140dc1f9be12fe"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cssparser",
  "derive_more",
  "fxhash",
@@ -3688,7 +3753,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b4d76501d8ba387cf0fefbe055c3e0a59891d09f0f995ae4e4b16f6b60f3c0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gio",
  "glib",
  "libc",
@@ -3702,7 +3767,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009ef427103fcb17f802871647a7fa6c60cbb654b4c4e4c0ac60a31c5f6dc9cf"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gio-sys",
  "glib-sys",
  "gobject-sys",
@@ -3883,7 +3948,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6fd7725dc1e593e9ecabd9fe49c112a204c8c8694db4182e78b2a5af490b1ae"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "cc",
  "cocoa",
@@ -4146,6 +4211,12 @@ name = "thin-slice"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
+
+[[package]]
+name = "thin-vec"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
 
 [[package]]
 name = "thiserror"
@@ -4614,7 +4685,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29952969fb5e10fe834a52eb29ad0814ccdfd8387159b0933edf1344a1c9cdcc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-rs",
  "gdk",
  "gdk-sys",
@@ -4639,7 +4710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d76ca6ecc47aeba01ec61e480139dda143796abcae6f83bcddf50d6b5b1dcf3"
 dependencies = [
  "atk-sys",
- "bitflags",
+ "bitflags 1.3.2",
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
  "gdk-sys",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ tauri-build = { version = "1.0.4", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.0.5", features = ["api-all"] }
-rhai-sci = { version = "0.1.9", features = ["smartcore", "nalgebra", "rand", "io"] }
+rhai-sci = { version = "0.1.9", default-features = false, features = ["nalgebra", "rand", "smartcore"] }
 rhai-ml = "0.1.2"
 rhai-fs = { version = "0.1.3", features = ["sync"] }
 rhai-url = "0.0.5"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,9 @@ serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.0.5", features = ["api-all"] }
 rhai-sci = { version = "0.1.9", features = ["smartcore", "nalgebra", "rand", "io"] }
 rhai-ml = "0.1.2"
+rhai-fs = { version = "0.1.3", features = ["sync"] }
+rhai-url = "0.0.5"
+rhai-rand = "0.1.6"
 rhai = { version = "1.9.0", features= ["sync"] }
 
 [features]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,0 +1,187 @@
+use std::sync::Arc;
+
+use rhai::packages::Package;
+use rhai::Shared;
+use serde_json::Error as SerdeError;
+
+pub type SharedModule = Shared<rhai::Module>;
+
+fn flatten_package_module<P>(package: &P) -> SharedModule
+where
+    P: Package,
+{
+    let shared = package.as_shared_module();
+    let mut module = rhai::Module::new();
+    module.combine_flatten((*shared).clone());
+    module.into()
+}
+
+fn build_rand_module() -> SharedModule {
+    let package = rhai_rand::RandomPackage::new();
+    flatten_package_module(&package)
+}
+
+fn build_fs_module() -> SharedModule {
+    let package = rhai_fs::FilesystemPackage::new();
+    flatten_package_module(&package)
+}
+
+fn build_url_module() -> SharedModule {
+    let package = rhai_url::UrlPackage::new();
+    flatten_package_module(&package)
+}
+
+fn build_ml_module() -> SharedModule {
+    let package = rhai_ml::MLPackage::new();
+    flatten_package_module(&package)
+}
+
+fn build_sci_module() -> SharedModule {
+    let package = rhai_sci::SciPackage::new();
+    flatten_package_module(&package)
+}
+
+pub fn configure_engine(mut engine: rhai::Engine) -> rhai::Engine {
+    engine.register_static_module("rand", build_rand_module());
+    engine.register_static_module("fs", build_fs_module());
+    engine.register_static_module("url", build_url_module());
+    engine.register_static_module("ml", build_ml_module());
+    engine.register_static_module("sci", build_sci_module());
+    engine
+}
+
+pub type OutputSink = Arc<dyn Fn(String) + Send + Sync + 'static>;
+
+/// Builds a JavaScript snippet that safely forwards a message to the frontend.
+///
+/// # Errors
+/// Returns an error if the message cannot be serialized with `serde_json`.
+pub fn append_output_script(message: &str) -> Result<String, SerdeError> {
+    serde_json::to_string(message).map(|escaped| format!("append_output({escaped})"))
+}
+
+pub fn run_rhai_script_with_sink(script: &str, sink: &OutputSink) {
+    let mut engine = configure_engine(rhai::Engine::new());
+
+    let print_sink = Arc::clone(sink);
+    engine.on_print(move |x| {
+        print_sink(x.to_string());
+    });
+
+    match engine.compile(script) {
+        Ok(script_ast) => match engine.eval_ast::<rhai::Dynamic>(&script_ast) {
+            Ok(result) => sink(result.to_string()),
+            Err(e) => sink(format!("{:?}", e)),
+        },
+        Err(e) => sink(e.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{append_output_script, run_rhai_script_with_sink, OutputSink};
+    use std::sync::{Arc, Mutex};
+
+    fn run_script_with_collector(script: &str) -> Vec<String> {
+        let captured_output: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_target = Arc::clone(&captured_output);
+        let sink: OutputSink = Arc::new(move |message: String| {
+            sink_target
+                .lock()
+                .expect("collector mutex poisoned")
+                .push(message);
+        });
+
+        run_rhai_script_with_sink(script, &sink);
+
+        let collected = captured_output
+            .lock()
+            .expect("collector mutex poisoned")
+            .clone();
+
+        collected
+    }
+
+    #[test]
+    fn append_output_script_serializes_control_characters() {
+        let result = append_output_script("Line 1\nLine 2\tTabbed")
+            .expect("failed to serialize message with control characters");
+        assert_eq!(result, "append_output(\"Line 1\\nLine 2\\tTabbed\")");
+    }
+
+    #[test]
+    fn append_output_script_preserves_quotes_and_unicode() {
+        let result = append_output_script("He said, \"hi\" ☃")
+            .expect("failed to serialize message with quotes and unicode");
+        assert_eq!(result, "append_output(\"He said, \\\"hi\\\" ☃\")");
+    }
+
+    #[test]
+    fn invalid_script_reports_parse_error() {
+        let output = run_script_with_collector("let x = ;");
+        let last_message = output
+            .last()
+            .expect("missing output entry for invalid script");
+
+        assert!(
+            last_message.contains("Unexpected"),
+            "expected parse error message, got: {last_message}",
+        );
+    }
+
+    #[test]
+    fn valid_script_reports_result() {
+        let output = run_script_with_collector("40 + 2");
+        assert!(
+            output.contains(&"42".to_string()),
+            "expected valid script to produce \"42\" but saw {output:?}",
+        );
+    }
+
+    #[test]
+    fn runtime_errors_are_forwarded_to_the_sink() {
+        let output = run_script_with_collector(
+            r#"
+            fn explode() { throw("boom"); }
+            explode();
+            "#,
+        );
+
+        let last_message = output
+            .last()
+            .expect("missing output entry for runtime error");
+        assert!(
+            last_message.contains("boom"),
+            "expected runtime error payload, got: {last_message}",
+        );
+    }
+
+    #[test]
+    fn print_statements_are_captured_before_results() {
+        let output = run_script_with_collector(r#"print("hi"); 41 + 1;"#);
+        assert_eq!(
+            output,
+            vec!["hi".to_string(), "42".to_string()],
+            "expected print output to precede the result",
+        );
+    }
+
+    #[test]
+    fn bundled_modules_are_available_under_namespaces() {
+        let output = run_script_with_collector(
+            r"
+            let value = rand::rand(0, 10);
+            value >= 0 && value <= 10
+            ",
+        );
+
+        let last_message = output
+            .last()
+            .expect("missing output entry for bundled module test");
+
+        assert_eq!(
+            last_message, "true",
+            "expected namespace-qualified module call to succeed",
+        );
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,30 +2,12 @@
     all(not(debug_assertions), target_os = "windows"),
     windows_subsystem = "windows"
 )]
+
 use std::sync::{Arc, Mutex};
 
-use rhai::packages::Package;
-use rhai_fs::FilesystemPackage;
-use rhai_ml::MLPackage;
-use rhai_rand::RandomPackage;
-use rhai_sci::SciPackage;
-use rhai_url::UrlPackage;
+use app::{append_output_script, configure_engine, run_rhai_script_with_sink, OutputSink};
+use rhai::{Dynamic, Engine, Scope};
 use tauri::Manager;
-
-/// Builds a JavaScript snippet that safely forwards a message to the frontend.
-///
-/// The message is serialized using `serde_json` so that newline characters,
-/// quotes, and other special characters remain valid once evaluated in the
-/// webview.
-///
-/// # Examples
-/// ```rust,ignore
-/// let script = append_output_script("Hello\nworld").unwrap();
-/// assert_eq!(script, "append_output(\"Hello\\nworld\")");
-/// ```
-fn append_output_script(message: &str) -> Result<String, serde_json::Error> {
-    serde_json::to_string(message).map(|escaped| format!("append_output({escaped})"))
-}
 
 fn send_output(window: &tauri::Window, message: &str) {
     match append_output_script(message) {
@@ -40,55 +22,14 @@ fn send_output(window: &tauri::Window, message: &str) {
     }
 }
 
-type SharedModule = rhai::Shared<rhai::Module>;
-
-fn flatten_package_module<P>(package: P) -> SharedModule
-where
-    P: Package,
-{
-    let shared = package.as_shared_module();
-    let mut module = rhai::Module::new();
-    module.combine_flatten((*shared).clone());
-    module.into()
-}
-
-fn build_rand_module() -> SharedModule {
-    flatten_package_module(RandomPackage::new())
-}
-
-fn build_fs_module() -> SharedModule {
-    flatten_package_module(FilesystemPackage::new())
-}
-
-fn build_url_module() -> SharedModule {
-    flatten_package_module(UrlPackage::new())
-}
-
-fn build_ml_module() -> SharedModule {
-    flatten_package_module(MLPackage::new())
-}
-
-fn build_sci_module() -> SharedModule {
-    flatten_package_module(SciPackage::new())
-}
-
-fn configure_engine(mut engine: rhai::Engine) -> rhai::Engine {
-    engine.register_static_module("rand", build_rand_module());
-    engine.register_static_module("fs", build_fs_module());
-    engine.register_static_module("url", build_url_module());
-    engine.register_static_module("ml", build_ml_module());
-    engine.register_static_module("sci", build_sci_module());
-    engine
-}
-
 struct MyState {
-    engine: Mutex<rhai::Engine>,
-    scope: Mutex<rhai::Scope<'static>>,
+    engine: Mutex<Engine>,
+    scope: Mutex<Scope<'static>>,
 }
 
 fn main() {
-    let engine = configure_engine(rhai::Engine::new());
-    let scope = rhai::Scope::new();
+    let engine = configure_engine(Engine::new());
+    let scope = Scope::new();
 
     let app_state = Arc::new(MyState {
         engine: Mutex::new(engine),
@@ -104,11 +45,6 @@ fn main() {
 
 #[tauri::command]
 fn rhai_script(script: &str, window: tauri::Window) {
-    let app_state = {
-        let state = window.state::<Arc<MyState>>();
-        Arc::clone(&state)
-    };
-
     let sink_window = window;
     let output_sink: OutputSink = Arc::new(move |message: String| {
         send_output(&sink_window, &message);
@@ -125,8 +61,11 @@ fn rhai_repl(script: &str, window: tauri::Window) {
         Arc::clone(&state)
     };
 
-    let mut engine = app_state.engine.lock().unwrap();
-    let mut scope = app_state.scope.lock().unwrap();
+    let mut engine = app_state
+        .engine
+        .lock()
+        .expect("shared engine mutex poisoned");
+    let mut scope = app_state.scope.lock().expect("shared scope mutex poisoned");
 
     let evaluation_window = window.clone();
     let print_window = window;
@@ -134,156 +73,8 @@ fn rhai_repl(script: &str, window: tauri::Window) {
         send_output(&print_window, message);
     });
 
-    match engine.eval_with_scope::<rhai::Dynamic>(&mut scope, script) {
+    match engine.eval_with_scope::<Dynamic>(&mut scope, script) {
         Ok(result) => send_output(&evaluation_window, &result.to_string()),
         Err(e) => send_output(&evaluation_window, &format!("{e:?}")),
-    }
-}
-
-type OutputSink = Arc<dyn Fn(String) + Send + Sync + 'static>;
-
-/// Executes a Rhai script and forwards every emitted message to the provided
-/// sink.
-///
-/// Messages include anything produced by the script via `print` as well as the
-/// final return value or runtime error.
-///
-/// # Examples
-/// ```rust,ignore
-/// let output = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-/// let sink_output = std::sync::Arc::clone(&output);
-/// let sink: OutputSink = std::sync::Arc::new(move |message: String| {
-///     sink_output
-///         .lock()
-///         .expect("failed to capture script output")
-///         .push(message);
-/// });
-///
-/// run_rhai_script_with_sink("40 + 2", &sink);
-/// assert_eq!(output.lock().unwrap().as_slice(), ["42"]);
-/// ```
-fn run_rhai_script_with_sink(script: &str, sink: &OutputSink) {
-    let mut engine = configure_engine(rhai::Engine::new());
-
-    let print_sink = Arc::clone(sink);
-    engine.on_print(move |x| {
-        print_sink(x.to_string());
-    });
-
-    match engine.compile(script) {
-        Ok(script_ast) => match engine.eval_ast::<rhai::Dynamic>(&script_ast) {
-            Ok(result) => sink(result.to_string()),
-            Err(e) => sink(format!("{:?}", e)),
-        },
-        Err(e) => sink(e.to_string()),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{append_output_script, run_rhai_script_with_sink, OutputSink};
-    use std::sync::{Arc, Mutex};
-
-    fn run_script_with_collector(script: &str) -> Vec<String> {
-        let captured_output: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-        let sink_target = Arc::clone(&captured_output);
-        let sink: OutputSink = Arc::new(move |message: String| {
-            sink_target
-                .lock()
-                .expect("collector mutex poisoned")
-                .push(message);
-        });
-
-        run_rhai_script_with_sink(script, &sink);
-
-        let collected = captured_output
-            .lock()
-            .expect("collector mutex poisoned")
-            .clone();
-
-        collected
-    }
-
-    #[test]
-    fn append_output_script_serializes_control_characters() {
-        let result = append_output_script("Line 1\nLine 2\tTabbed")
-            .expect("failed to serialize message with control characters");
-        assert_eq!(result, "append_output(\"Line 1\\nLine 2\\tTabbed\")");
-    }
-
-    #[test]
-    fn append_output_script_preserves_quotes_and_unicode() {
-        let result = append_output_script("He said, \"hi\" ☃")
-            .expect("failed to serialize message with quotes and unicode");
-        assert_eq!(result, "append_output(\"He said, \\\"hi\\\" ☃\")");
-    }
-
-    #[test]
-    fn invalid_script_reports_parse_error() {
-        let output = run_script_with_collector("let x = ;");
-        let last_message = output
-            .last()
-            .expect("missing output entry for invalid script");
-
-        assert!(
-            last_message.contains("Unexpected"),
-            "expected parse error message, got: {last_message}",
-        );
-    }
-
-    #[test]
-    fn valid_script_reports_result() {
-        let output = run_script_with_collector("40 + 2");
-        assert!(
-            output.contains(&"42".to_string()),
-            "expected valid script to produce \"42\" but saw {output:?}",
-        );
-    }
-
-    #[test]
-    fn runtime_errors_are_forwarded_to_the_sink() {
-        let output = run_script_with_collector(
-            r#"
-            fn explode() { throw("boom"); }
-            explode();
-            "#,
-        );
-
-        let last_message = output
-            .last()
-            .expect("missing output entry for runtime error");
-        assert!(
-            last_message.contains("boom"),
-            "expected runtime error payload, got: {last_message}",
-        );
-    }
-
-    #[test]
-    fn print_statements_are_captured_before_results() {
-        let output = run_script_with_collector(r#"print("hi"); 41 + 1;"#);
-        assert_eq!(
-            output,
-            vec!["hi".to_string(), "42".to_string()],
-            "expected print output to precede the result"
-        );
-    }
-
-    #[test]
-    fn bundled_modules_are_available_under_namespaces() {
-        let output = run_script_with_collector(
-            r#"
-            let value = rand::rand(0, 10);
-            value >= 0 && value <= 10
-            "#,
-        );
-
-        let last_message = output
-            .last()
-            .expect("missing output entry for bundled module test");
-
-        assert_eq!(
-            last_message, "true",
-            "expected namespace-qualified module call to succeed"
-        );
     }
 }


### PR DESCRIPTION
## Summary
- register additional bundled Rhai packages in the backend and expose them through the settings modal
- adjust the frontend modal messaging to reflect bundled packages and ensure options render
- document the bundled package set in the README

## Testing
- cargo test --manifest-path src-tauri/Cargo.toml *(fails: missing glib-2.0 system library)*

------
https://chatgpt.com/codex/tasks/task_e_68e132ab019c832592767f1ac0747eee