### PR TITLE
Add shared Rhai autocomplete across REPL and script editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ npm run tauri
 
 This will build the frontend, compile the Rust backend, and open the desktop shell with hot-reload enabled.
 
+### Editor assistance
+
+The embedded REPL and script workspace now use CodeMirror with Rhai-aware autocomplete:
+
+- Press <kbd>Ctrl</kbd> + <kbd>Space</kbd> to open the completion palette at any cursor location.
+- Start typing Rhai keywords or namespace prefixes (`rand::`, `fs::`, `url::`, `ml::`, `sci::`) to receive suggestions automatically.
+- Inside the REPL, <kbd>Enter</kbd> submits the current buffer while <kbd>Shift</kbd> + <kbd>Enter</kbd> inserts a newline without executing.
+
+The static completion source covers Rhai syntax primitives alongside the namespaces that `configure_engine` makes available so that common APIs remain one shortcut away.
+
 ## Bundled Rhai packages
 
 Pastrami preloads the curated [`rhaiscript`](https://github.com/orgs/rhaiscript/repositories?type=all) packages directly

--- a/dist/index.html
+++ b/dist/index.html
@@ -7,8 +7,41 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css"
           integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
     <style>
-        [contenteditable] {
-            outline: 0 solid transparent;
+        .repl-input-container {
+            display: flex;
+            align-items: flex-start;
+            gap: 0.5rem;
+            padding-bottom: 1rem;
+        }
+
+        #prompt_placeholder {
+            white-space: pre-wrap;
+            line-height: 25px;
+        }
+
+        #repl_input {
+            flex: 1;
+            min-height: 2rem;
+        }
+
+        #repl_input .CodeMirror {
+            background-color: transparent;
+            color: #ffc107;
+            height: auto;
+            min-height: 1.5em;
+            font-size: 0.875rem;
+        }
+
+        #repl_input .CodeMirror-cursor {
+            border-left: 1px solid #ffc107;
+        }
+
+        #repl_input .CodeMirror-lines {
+            padding: 0;
+        }
+
+        #repl_input .CodeMirror-scroll {
+            max-height: 12rem;
         }
     </style>
 </head>
@@ -18,16 +51,18 @@
         <div class="col h-100 min-vh-100 "style="background-color: #2B2B2B;">
             <code id="output" class="text-warning w-100 pt-3 d-table-cell"
                   style="white-space: pre-wrap; overflow-y:auto; line-height: 25px;"></code>
-            <code id="prompt_placeholder" class="text-warning d-inline"
-                  style="white-space: pre-wrap; line-height: 25px;">&gt;&gt;&gt; </code>
-            <code id="repl_input" class="text-warning d-inline pb-0 w-100"
-                  style="min-height: 1em; white-space: pre-wrap; min-width: 3em; margin-left: -4px; line-height: 25px;" contenteditable></code>
+            <div class="repl-input-container">
+                <code id="prompt_placeholder" class="text-warning d-inline">&gt;&gt;&gt; </code>
+                <wc-codemirror id="repl_input" mode="javascript" theme="darcula" class="text-warning w-100"
+                               style="background-color: transparent; overflow-y: auto;">
+                    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/vanillawc/wc-codemirror/theme/darcula.css">
+                </wc-codemirror>
+            </div>
         </div>
     </div>
 </div>
-<script>
-
-    document.getElementById("repl_input").focus();
+<script type="module">
+    import {configureRhaiCompletions, waitForCodeMirrorEditor} from './rhai-completions.js';
 
     // access the pre-bundled global API functions when available
     const tauriApi = window.__TAURI__ || {};
@@ -36,66 +71,8 @@
         : async () => {
             throw new Error('Tauri API not available');
         };
-    document.body.setAttribute('spellcheck', false);
 
-    document.getElementById("repl_input").addEventListener("keydown", function (e) {
-        if (e.code === "Enter" && e.shiftKey) {
-            e.preventDefault();
-            document.getElementById("repl_input").innerText += "\n";
-            PosEnd(document.getElementById("repl_input"));
-        } else if (e.code === "Enter") {
-            e.preventDefault();
-            let script = document.getElementById("repl_input").textContent;
-            document.getElementById("repl_input").innerText = "";
-            append_output(">>> " + script, false);
-            invoke('rhai_repl', {script: script}).catch((error) => {
-                append_output(`#Failed to run script: ${error}`);
-            });
-        }
-    });
-
-    function PosEnd(end) {
-        if (!end) {
-            return;
-        }
-
-        const textLength = (typeof end.textContent === "string")
-            ? end.textContent.length
-            : (typeof end.value === "string" ? end.value.length : 0);
-
-        if (typeof end.setSelectionRange === "function" && typeof end.value === "string") {
-            end.focus();
-            end.setSelectionRange(textLength, textLength);
-            return;
-        }
-
-        if (end.isContentEditable) {
-            end.focus();
-            const selection = window.getSelection();
-            if (!selection) {
-                return;
-            }
-
-            const range = document.createRange();
-            if (end.childNodes && end.childNodes.length > 0) {
-                range.setStart(end, end.childNodes.length);
-            } else {
-                range.selectNodeContents(end);
-            }
-            range.collapse(false);
-            selection.removeAllRanges();
-            selection.addRange(range);
-            return;
-        }
-
-        if (typeof end.createTextRange === "function") {
-            const textRange = end.createTextRange();
-            textRange.collapse(true);
-            textRange.moveEnd('character', textLength);
-            textRange.moveStart('character', textLength);
-            textRange.select();
-        }
-    }
+    document.body.setAttribute('spellcheck', 'false');
 
     function append_output(payload) {
         let message;
@@ -125,6 +102,41 @@
         const oph = document.getElementById("output_holder");
         oph.scroll({top: oph.scrollHeight, behavior: "smooth"});
     }
+
+    (async () => {
+        const replElement = document.getElementById('repl_input');
+        const replEditor = await waitForCodeMirrorEditor(replElement);
+        replEditor.setOption('lineNumbers', false);
+        replEditor.setOption('lineWrapping', true);
+        replEditor.setOption('viewportMargin', Infinity);
+
+        await configureRhaiCompletions(replEditor);
+
+        const runReplScript = () => {
+            const script = replEditor.getValue();
+            replEditor.setValue('');
+            append_output(`>>> ${script}`);
+            invoke('rhai_repl', {script}).catch((error) => {
+                append_output(`#Failed to run script: ${error}`);
+            });
+            replEditor.focus();
+        };
+
+        const existingKeys = replEditor.getOption('extraKeys') || {};
+        replEditor.setOption('extraKeys', {
+            ...existingKeys,
+            Enter: () => {
+                runReplScript();
+            },
+            'Shift-Enter': (cm) => {
+                cm.replaceSelection('\n');
+            }
+        });
+
+        replEditor.focus();
+    })().catch((error) => {
+        console.error('Failed to initialize the REPL editor', error);
+    });
 </script>
 <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
         integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"

--- a/dist/index_script.html
+++ b/dist/index_script.html
@@ -48,6 +48,19 @@
     </div>
     <!--      </div>-->
 </div>
+<script type="module">
+    import {configureRhaiCompletions, waitForCodeMirrorEditor} from './rhai-completions.js';
+
+    const scriptElement = document.getElementById('script');
+
+    (async () => {
+        const editor = await waitForCodeMirrorEditor(scriptElement);
+        await configureRhaiCompletions(editor);
+        window.pastramiScriptEditor = editor;
+    })().catch((error) => {
+        console.error('Failed to initialise the script workspace editor', error);
+    });
+</script>
 <script>
     // access the pre-bundled global API functions
     const tauriApi = window.__TAURI__ || {};
@@ -62,7 +75,9 @@
 
     function run_script() {
         toggle_spinner();
-        invoke('rhai_script', {script: document.getElementById("script").value}).catch((error) => {
+        const editor = window.pastramiScriptEditor;
+        const script = editor ? editor.getValue() : document.getElementById("script").value;
+        invoke('rhai_script', {script}).catch((error) => {
             append_output(`#Failed to run script: ${error}`);
             toggle_spinner();
         });

--- a/dist/rhai-completions.js
+++ b/dist/rhai-completions.js
@@ -1,0 +1,187 @@
+const RHAI_KEYWORDS = [
+    'if',
+    'else',
+    'switch',
+    'match',
+    'while',
+    'loop',
+    'for',
+    'in',
+    'let',
+    'const',
+    'mut',
+    'fn',
+    'private',
+    'return',
+    'break',
+    'continue',
+    'throw',
+    'try',
+    'catch',
+    'import',
+    'export',
+    'true',
+    'false',
+    'null',
+    'print',
+    'debug',
+    'type_of',
+    'this',
+    'is_shared',
+    'shared',
+    'eval'
+];
+
+const RHAI_NAMESPACES = ['rand', 'fs', 'url', 'ml', 'sci'];
+const RHAI_NAMESPACE_COMPLETIONS = RHAI_NAMESPACES.reduce((accumulator, namespace) => {
+    accumulator.push(namespace, `${namespace}::`);
+    return accumulator;
+}, []);
+const COMPLETIONS = [...new Set([...RHAI_KEYWORDS, ...RHAI_NAMESPACE_COMPLETIONS])].sort();
+
+let showHintLoadPromise = null;
+
+function ensureHintStylesheet() {
+    const existing = document.querySelector('link[data-rhai-hint-css="true"]');
+    if (existing) {
+        return;
+    }
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://cdn.jsdelivr.net/npm/codemirror@5.65.16/addon/hint/show-hint.min.css';
+    link.setAttribute('data-rhai-hint-css', 'true');
+    document.head.appendChild(link);
+}
+
+function waitForCodeMirrorGlobal() {
+    if (window.CodeMirror) {
+        return Promise.resolve(window.CodeMirror);
+    }
+
+    return new Promise((resolve, reject) => {
+        let attempts = 0;
+        const maxAttempts = 200;
+        const interval = window.setInterval(() => {
+            attempts += 1;
+            if (window.CodeMirror) {
+                window.clearInterval(interval);
+                resolve(window.CodeMirror);
+            } else if (attempts > maxAttempts) {
+                window.clearInterval(interval);
+                reject(new Error('CodeMirror failed to load before timeout.'));
+            }
+        }, 25);
+    });
+}
+
+async function ensureShowHintAssets() {
+    ensureHintStylesheet();
+    const codeMirror = await waitForCodeMirrorGlobal();
+
+    if (codeMirror.showHint) {
+        return codeMirror;
+    }
+
+    if (!showHintLoadPromise) {
+        showHintLoadPromise = new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = 'https://cdn.jsdelivr.net/npm/codemirror@5.65.16/addon/hint/show-hint.min.js';
+            script.async = true;
+            script.onload = () => resolve();
+            script.onerror = () => reject(new Error('Failed to load CodeMirror show-hint addon.'));
+            document.head.appendChild(script);
+        });
+    }
+
+    await showHintLoadPromise;
+    return waitForCodeMirrorGlobal();
+}
+
+function registerRhaiHintHelper(codeMirror) {
+    if (codeMirror.hint && codeMirror.hint.rhai) {
+        return;
+    }
+
+    codeMirror.registerHelper('hint', 'rhai', (editor) => {
+        const cursor = editor.getCursor();
+        const token = editor.getTokenAt(cursor);
+        const start = token.start;
+        const end = cursor.ch;
+        const prefix = token.string.slice(0, end - start);
+        const normalizedPrefix = prefix.replace(/[^A-Za-z0-9_:.]/g, '');
+        const filtered = COMPLETIONS.filter((candidate) => candidate.startsWith(normalizedPrefix));
+        const list = filtered.length > 0 ? filtered : COMPLETIONS;
+        return {
+            list,
+            from: codeMirror.Pos(cursor.line, start),
+            to: codeMirror.Pos(cursor.line, cursor.ch)
+        };
+    });
+}
+
+function mergeExtraKeys(editor, additionalKeys) {
+    const existingKeys = editor.getOption('extraKeys') || {};
+    editor.setOption('extraKeys', {...existingKeys, ...additionalKeys});
+}
+
+function shouldTriggerAutoComplete(changeEvent) {
+    if (!changeEvent || changeEvent.origin !== '+input') {
+        return false;
+    }
+
+    const text = (changeEvent.text || []).join('');
+    if (!text || text.trim().length === 0) {
+        return false;
+    }
+
+    return /^[A-Za-z0-9_.]$/.test(text);
+}
+
+export async function waitForCodeMirrorEditor(element) {
+    await customElements.whenDefined('wc-codemirror');
+
+    if (element.editor) {
+        return element.editor;
+    }
+
+    return new Promise((resolve, reject) => {
+        let attempts = 0;
+        const maxAttempts = 200;
+        const interval = window.setInterval(() => {
+            attempts += 1;
+            if (element.editor) {
+                window.clearInterval(interval);
+                resolve(element.editor);
+            } else if (attempts > maxAttempts) {
+                window.clearInterval(interval);
+                reject(new Error('wc-codemirror editor did not initialize in time.'));
+            }
+        }, 25);
+    });
+}
+
+export async function configureRhaiCompletions(editor) {
+    if (!editor) {
+        throw new Error('configureRhaiCompletions called without an editor instance.');
+    }
+
+    const codeMirror = await ensureShowHintAssets();
+    registerRhaiHintHelper(codeMirror);
+
+    mergeExtraKeys(editor, {
+        'Ctrl-Space': (cm) => {
+            cm.showHint({hint: codeMirror.hint.rhai});
+        }
+    });
+
+    editor.setOption('hintOptions', {
+        hint: codeMirror.hint.rhai,
+        completeSingle: false
+    });
+
+    editor.on('inputRead', (cm, change) => {
+        if (shouldTriggerAutoComplete(change)) {
+            cm.showHint({hint: codeMirror.hint.rhai});
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- replace the REPL contenteditable region with a CodeMirror-backed wc-codemirror editor and keep the existing execution shortcuts
- add a shared CodeMirror hint module that surfaces Rhai keywords and configured namespaces in both the REPL and script workspace
- document the new autocomplete feature and keyboard shortcuts in the README

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e15eb7cd8883259c743433af1416bb