### PR TITLE
Enable independent scrolling for script and REPL panels

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -19,7 +19,10 @@
             background-color: #2B2B2B;
             color: #fff;
             min-height: 100%;
+            height: 100%;
+            max-height: 100%;
             flex: 1 1 auto;
+            overflow: hidden;
         }
 
         .panel + .panel {
@@ -54,6 +57,7 @@
             flex-direction: column;
             gap: 1rem;
             min-height: 0;
+            overflow: hidden;
         }
 
         .panel-output {
@@ -75,6 +79,10 @@
             display: flex;
             align-items: flex-start;
             gap: 0.5rem;
+            margin-top: auto;
+            padding-top: 0.75rem;
+            border-top: 1px solid #1f1f1f;
+            background-color: #2B2B2B;
         }
 
         #prompt_placeholder {
@@ -105,11 +113,13 @@
 
         #repl_input .CodeMirror-scroll {
             max-height: 12rem;
+            overflow-y: auto;
         }
 
         .panel-body > wc-codemirror {
             flex: 1 1 auto;
             min-height: 0;
+            overflow: hidden;
         }
 
         #script_editor {
@@ -121,6 +131,11 @@
             color: #fff;
             height: 100%;
             font-size: 0.875rem;
+        }
+
+        #script_editor .CodeMirror-scroll {
+            height: 100%;
+            overflow-y: auto;
         }
 
         .panel-hidden {
@@ -401,11 +416,23 @@
 
         replEditor.setOption('lineNumbers', false);
         replEditor.setOption('lineWrapping', true);
-        replEditor.setOption('viewportMargin', Infinity);
+        replEditor.setOption('viewportMargin', 48);
 
         scriptEditor.setOption('lineNumbers', true);
         scriptEditor.setOption('lineWrapping', true);
-        scriptEditor.setOption('viewportMargin', Infinity);
+        scriptEditor.setOption('viewportMargin', 20);
+
+        const scriptWrapper = scriptEditor.getWrapperElement();
+        scriptWrapper.style.height = '100%';
+
+        const scriptScroller = scriptEditor.getScrollerElement();
+        scriptScroller.style.height = '100%';
+        scriptScroller.style.maxHeight = '100%';
+        scriptScroller.style.overflowY = 'auto';
+
+        const replScroller = replEditor.getScrollerElement();
+        replScroller.style.maxHeight = '12rem';
+        replScroller.style.overflowY = 'auto';
 
         await Promise.all([
             configureRhaiCompletions(replEditor),


### PR DESCRIPTION
## Summary
- constrain the script and REPL panels to the viewport and confine scrolling to each column
- tweak the CodeMirror editors so the script workspace scrolls independently and the REPL input stays sized
- style the REPL prompt container so it remains pinned at the bottom of its panel

## Testing
- Manual verification in browser (see screenshot)

------
https://chatgpt.com/codex/tasks/task_e_68e1b619ec688325969df52bf417fef3