### PR TITLE
Document GTK deps and use Rhai internals for completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ the application or its test suite:
     libayatana-appindicator3-dev \
     librsvg2-dev \
     libsoup2.4-dev \
+    libglib2.0-dev \
     patchelf
   ```
+  The `glib-2.0` development headers are necessary for crates that depend on `glib-sys`, including the GTK bindings pulled in
+  by Tauri's windowing layer.
 - macOS hosts require Xcode command-line tools (for SDK headers and signing utilities) in addition to the Rust and Node.js
   toolchains. Install the `aarch64-apple-darwin` Rust target via `rustup target add aarch64-apple-darwin` so universal bundles
   can be produced. The Tauri bundler will also use the system `codesign` binary during `npm run tauri build`.
@@ -30,7 +33,13 @@ the application or its test suite:
 > Ubuntu 24.04 publishes WebKitGTK 4.1. The bundled Tauri backend links against the same version, so the development
 > dependencies above install `libwebkit2gtk-4.1-dev` and `libjavascriptcoregtk-4.1-dev`. If you are building on an older
 > distribution that only ships WebKitGTK 4.0 you can still compile the application, but cross-version builds are not
-> supported.
+> supported. Should your linker complain about missing `libwebkit2gtk-4.0.so` or `libjavascriptcoregtk-4.0.so`, create
+> compatibility symlinks that point to the 4.1 versions, for example:
+> ```bash
+> sudo ln -sf /usr/lib/x86_64-linux-gnu/libwebkit2gtk-4.1.so /usr/lib/x86_64-linux-gnu/libwebkit2gtk-4.0.so
+> sudo ln -sf /usr/lib/x86_64-linux-gnu/libjavascriptcoregtk-4.1.so /usr/lib/x86_64-linux-gnu/libjavascriptcoregtk-4.0.so
+> ```
+> This mirrors the workaround we apply in CI so `cargo clippy` and `cargo test` can link successfully against WebKitGTK.
 
 ## Development workflow
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -16,15 +16,16 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.8.0"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
  "getrandom 0.2.7",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -4221,3 +4222,23 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ rhai-ml = "0.1.2"
 rhai-fs = { version = "0.1.3", features = ["sync"] }
 rhai-url = "0.0.5"
 rhai-rand = "0.1.6"
-rhai = { version = "1.9.0", features= ["sync"] }
+rhai = { version = "=1.23.3", features = ["sync", "internals"] }
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,7 +5,10 @@
 
 use std::sync::{Arc, Mutex};
 
-use app::{append_output_script, configure_engine, run_rhai_script_with_sink, OutputSink};
+use app::{
+    append_output_script, collect_completion_entries, configure_engine, run_rhai_script_with_sink,
+    OutputSink,
+};
 use rhai::{Dynamic, Engine, Scope};
 use tauri::Manager;
 
@@ -25,19 +28,26 @@ fn send_output(window: &tauri::Window, message: &str) {
 struct MyState {
     engine: Mutex<Engine>,
     scope: Mutex<Scope<'static>>,
+    completion_catalog: Vec<String>,
 }
 
 fn main() {
     let engine = configure_engine(Engine::new());
     let scope = Scope::new();
+    let completion_catalog = collect_completion_entries();
 
     let app_state = Arc::new(MyState {
         engine: Mutex::new(engine),
         scope: Mutex::new(scope),
+        completion_catalog,
     });
 
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![rhai_repl, rhai_script])
+        .invoke_handler(tauri::generate_handler![
+            rhai_completion_catalog,
+            rhai_repl,
+            rhai_script
+        ])
         .manage(app_state)
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -77,4 +87,16 @@ fn rhai_repl(script: &str, window: tauri::Window) {
         Ok(result) => send_output(&evaluation_window, &result.to_string()),
         Err(e) => send_output(&evaluation_window, &format!("{e:?}")),
     }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+#[tauri::command]
+fn rhai_completion_catalog(window: tauri::Window) -> Vec<String> {
+    let app_state = {
+        let app_handle = window.app_handle();
+        let state = app_handle.state::<Arc<MyState>>();
+        Arc::clone(state.inner())
+    };
+
+    app_state.completion_catalog.clone()
 }


### PR DESCRIPTION
## Summary
- document the libglib2.0 development package in the Linux prerequisites so GTK-linked crates build cleanly
- bump the Rhai dependency to 1.23.3 with the `internals` feature and gather completion items through `collect_fn_metadata`
- satisfy clippy for the completion command and reuse the cached catalog from shared state

## Testing
- cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e1bf829a20832592bb6a0f0bcbef71